### PR TITLE
Mineflayerボットの再接続制御を強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ docker compose up --build
 * `OPENAI_MODEL`: 既定 `gpt-5-mini`
 * `WS_URL`: Python→Node の WebSocket（既定 `ws://127.0.0.1:8765`）
 * `MC_HOST` / `MC_PORT`: Paper サーバー（既定 `localhost:25565`）
+* `MC_RECONNECT_DELAY_MS`: 接続失敗時に Mineflayer ボットが再接続を試みるまでの待機時間（ミリ秒、既定 `5000`）
 * `BOT_USERNAME`: ボットの表示名（例 `HelperBot`）
 * `AUTH_MODE`: `offline`（開発時推奨）/ `microsoft`
 


### PR DESCRIPTION
## 概要
- Mineflayerボットのライフサイクルを再設計し、接続失敗時に自動再接続するリトライ処理を追加
- Bot未接続時にはWSコマンドを安全に失敗させるガードを導入し、エラーログをわかりやすく改善
- 新しい `MC_RECONNECT_DELAY_MS` 環境変数をREADMEに追記し、再接続待機時間の設定方法を明文化

## テスト
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed22572184832cbd02e63296f2a906