### PR TITLE
Mineflayer を v4.33.0 へ更新して 1.21.8 サーバー対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ java -Xms4G -Xmx4G -jar paper-1.21.8-60.jar --nogui
 ### 3.1 Node（Mineflayer ボット）
 
 Node 側のボット実装は TypeScript 化しており、`npm start` を実行すると自動的にビルドと起動を行います。
+なお Mineflayer v4.33 系は Node.js 22 以降を要求するため、開発環境の Node バージョンが古い場合は `nvm` などでのアップデートを推奨します。
 
 ```bash
 cd node-bot

--- a/node-bot/package-lock.json
+++ b/node-bot/package-lock.json
@@ -8,8 +8,8 @@
       "name": "mc-llm-agent-bot",
       "version": "0.1.0",
       "dependencies": {
-        "minecraft-data": "^3.59.0",
-        "mineflayer": "^4.20.1",
+        "minecraft-data": "^3.99.1",
+        "mineflayer": "^4.33.0",
         "mineflayer-pathfinder": "^2.3.1",
         "ws": "^8.17.0"
       },
@@ -882,13 +882,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -962,9 +955,9 @@
       "license": "MIT"
     },
     "node_modules/minecraft-protocol": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.54.0.tgz",
-      "integrity": "sha512-v8pWRVhD9kyd/X52j/XESxrNxkmz1OHzSXAJkPLOQUUTENEqisJhu1c3abS7ZI+MAXHAEA/vaCb/Eh6XFxw0lA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.62.0.tgz",
+      "integrity": "sha512-+Rm7DdwgDiiq5ASXLNixs6TA7tsNn8zJAlhmOh0ccfuMYnlr/5+FliKacf87ZO6MPs5p/mJitIAwONbfqiX2+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node-rsa": "^1.1.4",
@@ -973,7 +966,6 @@
         "buffer-equal": "^1.0.0",
         "debug": "^4.3.2",
         "endian-toggle": "^0.0.0",
-        "lodash.get": "^4.1.2",
         "lodash.merge": "^4.3.0",
         "minecraft-data": "^3.78.0",
         "minecraft-folder-path": "^1.2.0",
@@ -989,23 +981,23 @@
         "yggdrasil": "^1.4.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=22"
       }
     },
     "node_modules/mineflayer": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-4.25.0.tgz",
-      "integrity": "sha512-q7cmpZFaSI6sodcMJxc2GkV8IO84HbsUP+xNipGKfGg+FMISKabzdJ838Axb60qRtZrp6ny7LluQE7lesHvvxQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-4.33.0.tgz",
+      "integrity": "sha512-tysUKVhUpEvHKDn8Awex/wz8WYyRGYrl6EujOVLJsGOU775AwKcapBVAS1BrP0UbM2di6MDwb74muGAFytY+TQ==",
       "license": "MIT",
       "dependencies": {
-        "minecraft-data": "^3.76.0",
-        "minecraft-protocol": "^1.51.0",
+        "minecraft-data": "^3.98.0",
+        "minecraft-protocol": "^1.61.0",
         "prismarine-biome": "^1.1.1",
-        "prismarine-block": "^1.17.0",
+        "prismarine-block": "^1.22.0",
         "prismarine-chat": "^1.7.1",
-        "prismarine-chunk": "^1.36.0",
-        "prismarine-entity": "^2.3.0",
-        "prismarine-item": "^1.15.0",
+        "prismarine-chunk": "^1.39.0",
+        "prismarine-entity": "^2.5.0",
+        "prismarine-item": "^1.17.0",
         "prismarine-nbt": "^2.0.0",
         "prismarine-physics": "^1.9.0",
         "prismarine-recipe": "^1.3.0",
@@ -1017,7 +1009,7 @@
         "vec3": "^0.1.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/mineflayer-pathfinder": {

--- a/node-bot/package.json
+++ b/node-bot/package.json
@@ -9,10 +9,10 @@
     "dev": "tsx watch bot.ts"
   },
   "dependencies": {
-    "mineflayer": "^4.20.1",
+    "mineflayer": "^4.33.0",
     "mineflayer-pathfinder": "^2.3.1",
     "ws": "^8.17.0",
-    "minecraft-data": "^3.59.0"
+    "minecraft-data": "^3.99.1"
   },
   "devDependencies": {
     "@types/node": "^20.16.5",


### PR DESCRIPTION
## 概要
- Mineflayer と minecraft-data を最新バージョンへ更新し、Paper 1.21.8 サーバーに接続できるようにしました
- Mineflayer の Node.js 22 以上という要件を README に追記し、開発環境構築時の注意点を明示しました

## テスト
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed29533b14832cb504a28cc61deb15