### PR TITLE
Prismarine依存更新とWS待受改善でPython接続を安定化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules/
 node-bot/dist/
 node-bot/*.tsbuildinfo
+node-bot/.env
+node-bot/.env.local
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker compose up --build
 * Python サービスは `watchfiles` を用いて `.py` ファイルの変更を検知し、`agent.py` を再実行します。
 * ホットリロード環境では依存ライブラリをコンテナ起動時に自動インストールするため、初回起動時は少し時間がかかります。
 * Docker Compose は `host.docker.internal` をコンテナの hosts に追加しています。Windows / WSL / macOS から Paper サーバーを起動している場合でも、ボットがホスト OS 上の `25565` ポートへ接続できます。
-* Node.js サービス用コンテナは `node:22` を採用し、`mineflayer@4.33.x` が必要とするエンジン条件を満たして `minecraft-protocol` の PartialReadError（`entity_equipment` の VarInt 解析失敗）を防止します。
+* Node.js サービス用コンテナは `node:22` を採用し、最新の Mineflayer 系ライブラリが要求するエンジン条件を満たして `minecraft-protocol` の PartialReadError（`entity_equipment` の VarInt 解析失敗）を防止します。
 
 #### 3.3.1 1.21.x の PartialReadError 追加対策
 
@@ -80,7 +80,8 @@ docker compose up --build
 * `OPENAI_API_KEY`: OpenAI の API キー
 * `OPENAI_BASE_URL`（任意）
 * `OPENAI_MODEL`: 既定 `gpt-5-mini`
-* `WS_URL`: Python→Node の WebSocket（既定 `ws://127.0.0.1:8765`）
+* `WS_URL`: Python→Node の WebSocket（既定 `ws://node-bot:8765`。Docker Compose ではサービス名解決で疎通）
+* `WS_HOST` / `WS_PORT`: Node 側 WebSocket サーバーのバインド先（既定 `0.0.0.0:8765`）
 * `MC_HOST` / `MC_PORT`: Paper サーバー（既定 `localhost:25565`、Docker 実行時は自動で `host.docker.internal` へフォールバック）
 * `MC_VERSION`: Mineflayer が利用する Minecraft プロトコルのバージョン。Paper 1.21.8 を想定した既定値 `1.21.8` を含め、minecraft-data が対応するラベルを指定してください。
 * `MC_RECONNECT_DELAY_MS`: 接続失敗時に Mineflayer ボットが再接続を試みるまでの待機時間（ミリ秒、既定 `5000`）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - "host.docker.internal:host-gateway" # Windows/macOS/WSL 環境から Paper サーバーへ接続するための名前解決
     env_file:
       - .env
+    environment:
+      WS_HOST: ${WS_HOST:-0.0.0.0}
+      WS_PORT: ${WS_PORT:-8765}
     command:
       - bash
       - -lc
@@ -34,6 +37,8 @@ services:
       - "host.docker.internal:host-gateway" # Python 側が Paper と通信する可能性に備え、同様に名前解決を登録
     env_file:
       - .env
+    environment:
+      WS_URL: ${WS_URL:-ws://node-bot:8765}
     command:
       - bash
       - -lc

--- a/env.example
+++ b/env.example
@@ -4,7 +4,9 @@ OPENAI_BASE_URL=
 OPENAI_MODEL=gpt-5-mini
 
 # WebSocket (Python -> Node)
-WS_URL=ws://127.0.0.1:8765
+WS_URL=ws://node-bot:8765
+WS_HOST=0.0.0.0
+WS_PORT=8765
 
 # Minecraft Server
 MC_HOST=127.0.0.1

--- a/node-bot/bot.ts
+++ b/node-bot/bot.ts
@@ -107,7 +107,9 @@ const MC_HOST = hostResolution.host;
 const MC_PORT = parseEnvInt(process.env.MC_PORT, 25565);
 const BOT_USERNAME = process.env.BOT_USERNAME ?? 'HelperBot';
 const AUTH_MODE = (process.env.AUTH_MODE ?? 'offline') as 'offline' | 'microsoft';
-const WS_PORT = 8765; // Python から接続
+// WebSocket 接続に関する構成。Docker ネットワーク上でも受信できるよう 0.0.0.0 を既定にする。
+const WS_HOST = process.env.WS_HOST ?? '0.0.0.0';
+const WS_PORT = parseEnvInt(process.env.WS_PORT, 8765);
 const MC_RECONNECT_DELAY_MS = parseEnvInt(process.env.MC_RECONNECT_DELAY_MS, 5000);
 
 // ---- Mineflayer ボット本体のライフサイクル管理 ----
@@ -214,8 +216,9 @@ function getActiveBot(): Bot | null {
 }
 
 // ---- WebSocket サーバ（Python -> Node） ----
-const wss = new WebSocketServer({ port: WS_PORT });
-console.log(`[WS] listening on ws://127.0.0.1:${WS_PORT}`);
+// Docker ブリッジ越しの Python エージェントが接続できるよう、host/port を明示的に指定する。
+const wss = new WebSocketServer({ host: WS_HOST, port: WS_PORT });
+console.log(`[WS] listening on ws://${WS_HOST}:${WS_PORT}`);
 
 // ---- WebSocket コマンド処理 ----
 // 1 接続につき 1 コマンドというシンプル設計。必要に応じて永続接続へ拡張予定。

--- a/node-bot/package-lock.json
+++ b/node-bot/package-lock.json
@@ -8,9 +8,11 @@
       "name": "mc-llm-agent-bot",
       "version": "0.1.0",
       "dependencies": {
-        "minecraft-data": "^3.99.1",
-        "mineflayer": "^4.33.0",
+        "minecraft-data": "latest",
+        "minecraft-protocol": "latest",
+        "mineflayer": "latest",
         "mineflayer-pathfinder": "^2.3.1",
+        "protodef": "latest",
         "ws": "^8.17.0"
       },
       "devDependencies": {

--- a/node-bot/package.json
+++ b/node-bot/package.json
@@ -13,10 +13,12 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "mineflayer": "^4.33.0",
+    "mineflayer": "latest",
     "mineflayer-pathfinder": "^2.3.1",
-    "ws": "^8.17.0",
-    "minecraft-data": "^3.99.1"
+    "minecraft-data": "latest",
+    "minecraft-protocol": "latest",
+    "protodef": "latest",
+    "ws": "^8.17.0"
   },
   "devDependencies": {
     "@types/node": "^20.16.5",

--- a/python/bridge_ws.py
+++ b/python/bridge_ws.py
@@ -11,7 +11,8 @@ logger = setup_logger("bridge")
 class BotBridge:
     """Python→Node WebSocket ブリッジ（単純な送信ユーティリティ）"""
     def __init__(self, ws_url: str | None = None) -> None:
-        self.ws_url = ws_url or os.getenv("WS_URL", "ws://127.0.0.1:8765")
+        # Docker Compose 実行時はサービス名でルーティングできるよう、node-bot ホストを既定とする。
+        self.ws_url = ws_url or os.getenv("WS_URL", "ws://node-bot:8765")
 
     async def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         logger.debug(f"WS send: {payload}")


### PR DESCRIPTION
## 概要
- mineflayer / minecraft-protocol / minecraft-data / protodef を最新バージョンへ更新し、Node 22 環境向けの lock を再生成しました
- WebSocket サーバーの待受ホストとポートを環境変数化して 0.0.0.0 で公開し、Docker Compose と python-agent がサービス名で通信できるようにしました
- env.example / README / .gitignore を新しい接続設定と秘匿ファイルルールに合わせて同期しました

## テスト
- npm --prefix node-bot install --force
- npm --prefix node-bot audit fix（403 Forbidden のため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68ed44dc8864832c9b84bb305b3d934b