### PR TITLE
Paper 1.21.1 を既定バージョンとして各設定を統一

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ python/.env
 *.pem
 *.key
 *.p12
+# Local Paper server binaries（バージョン固定の jar を誤コミットしないための安全策）
+paper.jar
+paper-*.jar
 
 # Editor and OS artifacts
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minecraft 自律ボット（Python + gpt-5-mini + Mineflayer）
 
-本プロジェクトは、Minecraft Java Edition 1.21.8 + Paper 上で動作する **日本語対応の LLM 自律ボット** です。  
+本プロジェクトは、Minecraft Java Edition 1.21.1 + Paper 上で動作する **日本語対応の LLM 自律ボット** です。
 Python 側が LLM（OpenAI **gpt-5-mini**）でチャット意図を解釈し、Node.js 側の Mineflayer ボットへ行動コマンドを送ります。
 
 ## 1. できること（初期）
@@ -12,11 +12,19 @@ Python 側が LLM（OpenAI **gpt-5-mini**）でチャット意図を解釈し、
 - 簡易建築：小屋/倉庫などの原始的建築
 - プレイヤー随伴：「ついてきて」で追尾モード
 
+## バージョン方針
+
+本プロジェクトは既定で **Minecraft Java / Paper 1.21.1** を使用します。Paper サーバーの JAR は `paper-1.21.1-*.jar` を取得して `paper.jar` にリネームし、`C:\mc\paper\paper.jar` など任意の配置先で保守してください。Bot 側の既定プロトコルも `MC_VERSION=1.21.1` を参照するため、サーバーとクライアントの齟齬を防ぎます。将来的に別バージョンを試す場合は `.env` の `MC_VERSION` や `paper.jar` を差し替えるだけで移行できます。
+
+### クライアントとの互換性
+
+原則として Minecraft クライアントも 1.21.1 を利用してください。1.21.1 以外のクライアントから接続する必要がある場合は、Paper サーバーに ViaVersion / ViaBackwards などの互換プラグインを導入して調整します（完全互換ではない点に留意）。
+
 ## 2. Paper サーバーの起動（前提）
 Windows 例：
 ```powershell
 cd C:\mc\paper
-java -Xms4G -Xmx4G -jar paper-1.21.8-60.jar --nogui
+java -Xms4G -Xmx4G -jar .\paper.jar --nogui
 ```
 
 開発中は `server.properties` の `online-mode=false` を推奨。
@@ -69,9 +77,9 @@ docker compose up --build
 #### 3.3.1 1.21.x の PartialReadError 追加対策
 
 - Paper / Vanilla 1.21.4 以降では ItemStack (Slot 型) に optional NBT が 2 セクション追加され、旧定義のままでは `entity_equipment` パケットで 2 バイトの読み残しが発生します。
-- `node-bot/runtime/slotPatch.ts` で `customPackets` 用の Slot 定義を動的に生成し、1.21 ～ 1.21.8 系の亜種をまとめて上書きすることで `PartialReadError: Unexpected buffer end while reading VarInt` を解消しています。minecraft-data のバージョン一覧から自動検出しているため、新しい 1.21.x がリリースされても追従漏れを起こしません。
+- `node-bot/runtime/slotPatch.ts` で `customPackets` 用の Slot 定義を動的に生成し、1.21 ～ 1.21.x 系の亜種をまとめて上書きすることで `PartialReadError: Unexpected buffer end while reading VarInt` を解消しています。minecraft-data のバージョン一覧から自動検出しているため、新しい 1.21.x がリリースされても追従漏れを起こしません。
 - 1.21.3 以前ではこれらのフィールドが送られないため、option タイプの 0 バイトだけが届き互換性が維持されます。
-- `.env` で `MC_VERSION=1.21.8` のように **minecraft-data が認識するプロトコルラベル** を指定すると、Mineflayer がサーバーと同じ定義で通信を開始するため、`PartialReadError` の再発リスクを減らせます。未設定時は既定で 1.21.8 を採用し、未知の値が入力された場合は対応可能なバージョンへ自動フォールバックします。
+- `.env` で `MC_VERSION=1.21.1` のように **minecraft-data が認識するプロトコルラベル** を指定すると、Mineflayer がサーバーと同じ定義で通信を開始するため、`PartialReadError` の再発リスクを減らせます。未設定時は既定で 1.21.1 を採用し、未知の値が入力された場合は対応可能なバージョンへ自動フォールバックします。
 
 ## 4. .env
 
@@ -83,7 +91,7 @@ docker compose up --build
 * `WS_URL`: Python→Node の WebSocket（既定 `ws://node-bot:8765`。Docker Compose ではサービス名解決で疎通）
 * `WS_HOST` / `WS_PORT`: Node 側 WebSocket サーバーのバインド先（既定 `0.0.0.0:8765`）
 * `MC_HOST` / `MC_PORT`: Paper サーバー（既定 `localhost:25565`、Docker 実行時は自動で `host.docker.internal` へフォールバック）
-* `MC_VERSION`: Mineflayer が利用する Minecraft プロトコルのバージョン。Paper 1.21.8 を想定した既定値 `1.21.8` を含め、minecraft-data が対応するラベルを指定してください。
+* `MC_VERSION`: Mineflayer が利用する Minecraft プロトコルのバージョン。Paper 1.21.1 を想定した既定値 `1.21.1` を含め、minecraft-data が対応するラベルを指定してください。
 * `MC_RECONNECT_DELAY_MS`: 接続失敗時に Mineflayer ボットが再接続を試みるまでの待機時間（ミリ秒、既定 `5000`）
 * `BOT_USERNAME`: ボットの表示名（例 `HelperBot`）
 * `AUTH_MODE`: `offline`（開発時推奨）/ `microsoft`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     env_file:
       - .env
     environment:
+      # Mineflayer が Paper と揃った既定バージョンで起動するよう docker-compose 側でもフォールバックを指定する。
+      MC_VERSION: ${MC_VERSION:-1.21.1}
       WS_HOST: ${WS_HOST:-0.0.0.0}
       WS_PORT: ${WS_PORT:-8765}
     command:
@@ -38,7 +40,8 @@ services:
     env_file:
       - .env
     environment:
-      WS_URL: ${WS_URL:-ws://node-bot:8765}
+      # Node 側が公開する WebSocket ポートを 1 箇所で可変化し、複数環境での疎通設定を単純化する。
+      WS_URL: ${WS_URL:-ws://node-bot:${WS_PORT:-8765}}
     command:
       - bash
       - -lc

--- a/env.example
+++ b/env.example
@@ -11,7 +11,7 @@ WS_PORT=8765
 # Minecraft Server
 MC_HOST=127.0.0.1
 MC_PORT=25565
-MC_VERSION=1.21.8
+MC_VERSION=1.21.1
 
 # Bot Auth / Identity
 BOT_USERNAME=HelperBot

--- a/node-bot/bot.ts
+++ b/node-bot/bot.ts
@@ -21,7 +21,8 @@ const { pathfinder, Movements, goals } = mineflayerPathfinder as typeof import('
 // 詳細な Slot 構造体の上書きロジックは runtime/slotPatch.ts に切り出し、複数バージョンへ一括適用する。
 
 // ---- プロトコルバージョン制御 ----
-const DEFAULT_MC_VERSION = '1.21.8';
+// Paper サーバーと Mineflayer の既定バージョン整合性を保つため、ここで既定値を一元管理する。
+const DEFAULT_MC_VERSION = '1.21.1';
 const SUPPORTED_MINECRAFT_VERSIONS = new Set(
   minecraftData.versions.pc.map((version) => version.minecraftVersion),
 );


### PR DESCRIPTION
# Codex 開発指示書：標準仕様を Paper 1.21.1 へ統一（mc-bot-egent-practice-1）

## 目的
- **サーバ実行環境の既定バージョンを Paper 1.21.1 に降格・固定**し、Bot 側も **既定プロトコル 1.21.1** に統一する。
- 将来的に再び 1.21.8 へ戻す場合でも変更差分が最小になるように、**バージョンを .env と単一 `paper.jar` に抽象化**する。

---

## スコープ
- リポジトリ：`RiSEblackbird/mc-bot-egent-practice-1`
- 対象：`node-bot`（TypeScript, mineflayer）、`python-agent`（WS クライアント）、ホスト Windows 上の Paper サーバ
- 既定バージョン：**1.21.1**

---

## 変更サマリ
1. **.env.example** の `MC_VERSION` 既定値を `1.21.1` に変更。
2. **node-bot** の「未設定時フォールバック」メッセージ＆既定プロトコルを `1.21.1` に変更。
3. **docker-compose.yml**：`MC_VERSION` を `node-bot` へ渡す（未設定なら 1.21.1）。WS の到達性は `0.0.0.0:8765` を既定に。
4. **Paper サーバ**：`paper-1.21.1-*.jar` を `paper.jar` として配置。起動スクリプトを jar 非依存化。
5. 依存更新（Prismarine 系は最新安定のまま）とクリーン再ビルド。
6. 検証とロールバック手順整備。

---

## 具体作業

### 1) `.env.example` の既定値更新
```diff
# .env.example
-MC_VERSION=1.21.8
+MC_VERSION=1.21.1
 WS_HOST=0.0.0.0
 WS_PORT=8765
````

> 既存プロジェクトで `.env` を持つ場合は、**.env は自動変更しない**（利用者ローカル優先）。必要に応じて README に移行手順を記載。

---

### 2) `node-bot` のフォールバック既定を 1.21.1 へ

* 「環境変数未設定なら 1.21.8」→「**1.21.1**」へ変更。
* 例：`bot.ts` 内のバージョン決定ロジック・ログ出力。

```diff
- console.log("[Bot] 環境変数 MC_VERSION が未設定のため、既定プロトコル 1.21.8 を利用します。");
+ console.log("[Bot] 環境変数 MC_VERSION が未設定のため、既定プロトコル 1.21.1 を利用します。");

- const PROTO = process.env.MC_VERSION ?? "1.21.8";
+ const PROTO = process.env.MC_VERSION ?? "1.21.1";
```

* 併せて WebSocket の待受をホスト/ポート可変・外部到達可能に維持（既に対応済みなら差分不要）。

```diff
- const wss = new WebSocketServer({ port: 8765 });
+ const WS_HOST = process.env.WS_HOST ?? "0.0.0.0";
+ const WS_PORT = Number(process.env.WS_PORT ?? "8765");
+ const wss = new WebSocketServer({ host: WS_HOST, port: WS_PORT });
+ console.log(`[WS] listening on ws://${WS_HOST}:${WS_PORT}`);
```

---

### 3) `docker-compose.yml` の環境伝搬と公開

* `node-bot` に `MC_VERSION` を伝搬、WS を公開。`python-agent` からは内部 DNS 名で接続。

```diff
 services:
   node-bot:
     build: ./node-bot
+    environment:
+      - MC_VERSION=${MC_VERSION:-1.21.1}
+      - WS_HOST=${WS_HOST:-0.0.0.0}
+      - WS_PORT=${WS_PORT:-8765}
+    ports:
+      - "8765:8765"
     depends_on:
       - python-agent

   python-agent:
     build: ./python-agent
+    environment:
+      - WS_URL=ws://node-bot:${WS_PORT:-8765}
     depends_on:
       - node-bot
```

> 既存の他環境変数があれば保持。未定義時は 1.21.1 を用いる。

---

### 4) Paper サーバ（ホスト Windows）を 1.21.1 に統一

1. 最新の **Paper 1.21.1** JAR を取得（`paper-1.21.1-<build>.jar`）。
2. `C:\mc\paper\` に配置し、**`paper.jar` にリネーム**（ビルド番号差分を吸収）。
3. 起動スクリプトを jar 名非依存に更新。

**PowerShell 例（`run-paper.ps1`）**

```powershell
Set-Location C:\mc\paper
java -Xms4G -Xmx4G -jar .\paper.jar --nogui
```

**初回同意（未済なら）**

```powershell
java -jar .\paper.jar --version
```

> 既存の `paper-1.21.8-*.jar` は退避。クライアント（Minecraft）側も 1.21.1 を利用するのが原則。もし 1.21.8 クライアントから接続したい場合は、サーバ側に ViaVersion + ViaBackwards を導入する（任意）。

---

### 5) 依存整備とクリーン再ビルド

* Prismarine 系は 1.21.1 を問題なく処理可能。`node-bot` の依存を更新し lock を刷新。

```bash
# ルートまたは node-bot ディレクトリから
rm -f node-bot/package-lock.json
npm --prefix node-bot i
npm --prefix node-bot audit fix || true

# 孤児/ボリューム掃除 → 再ビルド
docker compose down --remove-orphans -v
docker compose build --no-cache
docker compose up
```

---

## 受け入れ条件（Validation）

* Paper サーバを **1.21.1** で起動し、`node-bot` が **プロトコル 1.21.1** で接続すること（起動ログで確認）。
* `PartialReadError`（`declare_recipes` / `recipe_book_add` / `advancements` / `entity_equipment` 等）で直後に落ちないこと。
* `node-bot` ログに `listening on ws://0.0.0.0:8765`（または設定値）が出力され、`python-agent` が `ws://node-bot:8765` で接続できること。
* `docker compose up` 実行時に孤児コンテナ警告が出ないこと。

---

## README 追記（抜粋テンプレート）

```diff
+## バージョン方針
+本プロジェクトは既定で **Minecraft Java / Paper 1.21.1** を使用します。
+Bot 側の既定プロトコルは `MC_VERSION=1.21.1`（`.env` で変更可能）。
+サーバの JAR は `C:\mc\paper\paper.jar` に配置してください（1.21.1 系）。
+
+### クライアントとの互換
+原則 1.21.1 クライアントを使用してください。
+1.21.8 クライアントから接続する必要がある場合は、Paper サーバに ViaVersion + ViaBackwards を導入することで上位互換を許容できます（完全互換ではない点に留意）。
```

---

## ロールバック

* 一時的に 1.21.8 へ戻す場合：

  * `.env` の `MC_VERSION=1.21.8` に変更。
  * `paper.jar` を `paper-1.21.8-*.jar` に差し替え（または `paper.jar` を 1.21.8 ビルドへ上書き）。
  * `docker compose down --remove-orphans -v && docker compose up --build`

---

## 補足（任意）

* 既存のフォルダ構造・スクリプト名が異なる場合は、本指示のコマンド/パスをリポジトリに合わせて調整。
* Windows ファイアウォールが 25565/TCP を遮断している場合は許可する。
* 依存の大幅更新が必要な場合はブランチを切り、`npm audit fix --force` は別ブランチで動作確認後にマージする。

```

---

## 概要
- Mineflayer の既定プロトコルを 1.21.1 へ更新し、docker-compose からも同値が渡るよう整理しました
- .env テンプレートと README を 1.21.1 前提の手順へ差し替え、Paper jar を paper.jar として扱う運用を明文化しました
- 誤コミット防止のため Paper サーバーの jar を .gitignore に追加しました

## 動作確認
- 特になし（設定値のみの変更のため）

------
https://chatgpt.com/codex/tasks/task_e_68f352625498832ca4f787e631d93139