### PR TITLE
Mineflayer スロットパッチの誤った末尾フィールドを削除

### DIFF
--- a/node-bot/runtime/slotPatch.ts
+++ b/node-bot/runtime/slotPatch.ts
@@ -38,6 +38,10 @@ export function collectSlotProtocolVersions(
 
 /**
  * 追加フィールドを考慮した Slot 定義を生成する。
+ *
+ * 注意点：Paper 1.21.1 では tailCustomData/tailItemData のような末尾フィールドは送信されない。
+ * これらを誤って追加すると、Mineflayer 側で itemCount 読み取り時に巨大な配列長を解釈して
+ * `array size is abnormally large` エラーが発生するため、公式プロトコル定義と同じ構造を厳守する。
  * オブジェクトは Mineflayer 側で書き換えられる可能性があるため、都度新しい参照を返す。
  */
 function createSlotOverride(): { types: Record<string, unknown> } {
@@ -74,8 +78,6 @@ function createSlotOverride(): { types: Record<string, unknown> } {
                         },
                       ],
                     },
-                    { name: 'tailCustomData', type: ['option', 'anonymousNbt'] },
-                    { name: 'tailItemData', type: ['option', 'anonymousNbt'] },
                   ],
                 ],
               },

--- a/node-bot/tests/slotPatch.test.ts
+++ b/node-bot/tests/slotPatch.test.ts
@@ -30,6 +30,34 @@ describe('buildCustomSlotPatch', () => {
     const patch = buildCustomSlotPatch(['1.21', '1.21.1']);
     expect(patch['1.21']).not.toBe(patch['1.21.1']);
   });
+
+  it('Slot 定義へ未対応の末尾フィールドを追加しない', () => {
+    const patch = buildCustomSlotPatch(['1.21.1']);
+    const slotDefinition = patch['1.21.1'].types.Slot as [string, unknown[]];
+    const [, slotEntries] = slotDefinition;
+    const switchDescriptor = slotEntries.find(
+      (entry): entry is { type: unknown[] } =>
+        typeof entry === 'object' && entry !== null && 'type' in (entry as Record<string, unknown>),
+    );
+
+    expect(switchDescriptor).toBeDefined();
+
+    const switchPayload = switchDescriptor!.type as unknown[];
+    const switchConfig = switchPayload[1] as { default: unknown[] };
+    const defaultContainer = switchConfig.default as unknown[];
+    const defaultEntries = defaultContainer[1] as Array<Record<string, unknown>>;
+    const fieldNames = defaultEntries
+      .filter((entry) => typeof entry === 'object' && entry !== null && 'name' in entry)
+      .map((entry) => entry.name as string);
+
+    expect(fieldNames).toEqual([
+      'itemId',
+      'addedComponentCount',
+      'removedComponentCount',
+      'components',
+      'removeComponents',
+    ]);
+  });
 });
 
 describe('CUSTOM_SLOT_PATCH', () => {


### PR DESCRIPTION
## 概要
- Paper 1.21.1 に存在しない tailCustomData / tailItemData フィールドをスロットパッチから除外し、異常な配列サイズ例外を防止
- 末尾フィールドを追加しないことを検証する単体テストを追加し、将来の退行を検知できるように調整

## テスト
- Node.js 22.x がローカル環境に存在しないため npm --prefix node-bot install が EBADENGINE で失敗（CI 等の Node 22.x 環境で再実行を推奨）

------
https://chatgpt.com/codex/tasks/task_e_68f35d7b5da8832ca3b9f9c3ff791041