### PR TITLE
LLMエージェントとMineflayer間の双方向WebSocket連携を実装

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       MC_VERSION: ${MC_VERSION:-1.21.1}
       WS_HOST: ${WS_HOST:-0.0.0.0}
       WS_PORT: ${WS_PORT:-8765}
+      AGENT_WS_URL: ${AGENT_WS_URL:-ws://python-agent:${AGENT_WS_PORT:-9000}}
     command:
       - bash
       - -lc
@@ -42,6 +43,8 @@ services:
     environment:
       # Node 側が公開する WebSocket ポートを 1 箇所で可変化し、複数環境での疎通設定を単純化する。
       WS_URL: ${WS_URL:-ws://node-bot:${WS_PORT:-8765}}
+      AGENT_WS_HOST: ${AGENT_WS_HOST:-0.0.0.0}
+      AGENT_WS_PORT: ${AGENT_WS_PORT:-9000}
     command:
       - bash
       - -lc

--- a/env.example
+++ b/env.example
@@ -8,6 +8,12 @@ WS_URL=ws://node-bot:8765
 WS_HOST=0.0.0.0
 WS_PORT=8765
 
+# WebSocket (Node -> Python)
+AGENT_WS_HOST=0.0.0.0
+AGENT_WS_PORT=9000
+AGENT_WS_URL=ws://python-agent:9000
+DEFAULT_MOVE_TARGET=0,64,0
+
 # Minecraft Server
 MC_HOST=127.0.0.1
 MC_PORT=25565


### PR DESCRIPTION
実用に足るようにします。元の開発計画通り、エージェントを実装してください。

node-bot-1      | [Chat] 自動処理ルーティングは未実装のため、Node 側で受信ログのみを記録しました。

---

## 概要
- Python エージェントを常駐型の WebSocket サーバーとして再構築し、チャット受付から LLM 計画生成、Mineflayer への指示送出までを自動化
- Node 側でプレイヤーチャットを検知すると Python へ即座にフォワードする橋渡しロジックを実装し、Docker Compose も含めた環境変数を拡充
- README や env.example を更新し、新しい連携フロー・設定項目・デバッグ手順を詳細に記載

## テスト
- `python -m compileall python`
- `npm test`（ローカル Node.js 20.19.4 ではエンジン要件 >=22.0.0 を満たさず失敗）

------
https://chatgpt.com/codex/tasks/task_e_68f3627fa34c832ca81e6571aa247fa2