### PR TITLE
watchfilesコマンドの引用ミスによるPythonエージェント未起動を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ docker compose up --build
 ```
 
 * Node サービスは `npm run dev`（`tsx` を利用）で TypeScript ソースの変更を検知し、自動的に再起動します。
-* Python サービスは `watchfiles` を用いて `.py` ファイルの変更を検知し、`agent.py` を再実行します。
+* Python サービスは `watchfiles` を用いて `.py` ファイルの変更を検知し、`agent.py` を再実行します。なお CLI の仕様上、
+  `watchfiles -- ...` に渡すコマンドは `"python agent.py"` のように 1 引数へクォートしておかないと、Python が
+  対話モードで起動してポートをリッスンしない（Node からの接続が `ECONNREFUSED` になる）点に注意してください。
 * ホットリロード環境では依存ライブラリをコンテナ起動時に自動インストールするため、初回起動時は少し時間がかかります。
 * Docker Compose は `host.docker.internal` をコンテナの hosts に追加しています。Windows / WSL / macOS から Paper サーバーを起動している場合でも、ボットがホスト OS 上の `25565` ポートへ接続できます。
 * Node.js サービス用コンテナは `node:22` を採用し、最新の Mineflayer 系ライブラリが要求するエンジン条件を満たして `minecraft-protocol` の PartialReadError（`entity_equipment` の VarInt 解析失敗）を防止します。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       - |
         pip install --no-cache-dir -r requirements.txt \
         && cd python \
-        && watchfiles --filter python --ignore-paths .venv -- python agent.py
+        && \ 
+          # watchfiles CLI ではコマンド全体を 1 引数として渡さないと Python が対話モードで起動してしまい、
+          # エージェントがポートをリッスンしないため明示的にクォートする。
+          watchfiles --filter python --ignore-paths .venv -- "python agent.py"
     stdin_open: true
     tty: true


### PR DESCRIPTION
## 概要
- docker-compose の Python サービス起動コマンドを修正し、watchfiles が Python を対話モードで立ち上げないようにした
- README に watchfiles コマンドの引用要件と、誤ると ECONNREFUSED になる注意書きを追記

## テスト
- 未実施（ドキュメントおよびコンテナ起動コマンドの修正のみのため）

------
https://chatgpt.com/codex/tasks/task_e_68f366d217e8832c96ae03104e324c27