### PR TITLE
MineDojoミッション連携の実装とデモ注入の自動化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ node-bot/coverage/
 # Skill library runtime storage（学習履歴やプレイヤー座標を含むため除外）
 var/skills/
 python/skills/*.runtime.json
+# MineDojo 連携で使用するキャッシュ/データセット（API 応答やデモ軌跡に秘匿情報が含まれる）
+var/cache/minedojo/
+var/datasets/minedojo/
 # Reflexion ログの永続化ファイル（失敗手順や復旧履歴に敏感情報が含まれるため除外）
 var/memory/
 # VPT 推論用のチェックポイントや推論キャッシュ（再配布禁止ライセンスに抵触する恐れがあるため除外）

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Python 側で LLM プランニングとアクション実行が行われます�
 フェーズ定義・遷移条件・ロールバック指針を整理しており、長期ジョブを中断しても
 安全に再開できるようチェックポイント設計の前提を共有しています。
 
+#### MineDojo ミッション連携
+
+* Python エージェントは行動タスクの分類結果から MineDojo ミッション ID を推論し、該当カテゴリでは `python/services/minedojo_client.py` を介してミッション情報とデモを取得します。
+* 取得したデモは `Actions.play_vpt_actions` に対して自動送信され、Mineflayer 側で低レベル操作を事前ロードします。同時に LLM コンテキストへミッション概要とデモ要約（アクション種別・件数）が注入されるため、計画生成時に具体的な事例を参照できます。
+* API 経由で MineDojo を利用する場合は `.env`（または環境変数）へ `MINEDOJO_API_KEY` を設定してください。ローカルデータセットを参照する場合は `MINEDOJO_DATASET_DIR` に JSON の配置ディレクトリ（`missions/mission_id.json`・`demos/mission_id.json`）を指定します。
+* キャッシュは `MINEDOJO_CACHE_DIR`（既定: `var/cache/minedojo`）へ保存されます。API 応答やデモ軌跡にはライセンス制限・個人データが含まれる可能性があるため、リポジトリへコミットしないでください。`.gitignore` にも除外設定を追加済みです。
+* 具体的なディレクトリ構成やデータ利用ポリシーは `docs/minedojo_integration.md` を参照してください。MineDojo 利用規約に従い、商用利用可否や二次配布の扱いをチーム内で確認してください。
+
 #### LangGraph 構造化ログとリカバリー
 
 * `python/utils/logging.py` に構造化ロギングユーティリティを追加し、LangGraph ノード ID・チェックポイント ID・イベントレベルを JSON 形式で出力します。`log_structured_event` を利用すると、ノード固有の `context` メタデータを辞書で渡せます。
@@ -195,6 +203,11 @@ python -m python.cli tunnel --world world --anchor 100 12 200 --dir 1 0 0 --sect
 * `MOVE_GOAL_TOLERANCE`: moveTo コマンドで利用する GoalNear の許容距離（ブロック数）。既定値は `3` で、1～30 の範囲に丸められます。
 * `BOT_USERNAME`: ボットの表示名（例 `HelperBot`）
 * `AUTH_MODE`: `offline`（開発時推奨）/ `microsoft`
+* `MINEDOJO_API_BASE_URL`: MineDojo API のベース URL（既定: `https://api.minedojo.org/v1`）
+* `MINEDOJO_API_KEY`: MineDojo API キー。未設定の場合はローカルデータセットのみ参照します。
+* `MINEDOJO_DATASET_DIR`: ローカルに配置した MineDojo データセットのルートディレクトリ。`missions/` と `demos/` サブディレクトリを想定。
+* `MINEDOJO_CACHE_DIR`: API 応答やデモをキャッシュするディレクトリ（既定: `var/cache/minedojo`）
+* `MINEDOJO_REQUEST_TIMEOUT`: API リクエストのタイムアウト秒数（既定: `10.0`）。0 以下の値は警告の上で既定値に丸められます。
 
 ## 5. 使い方（ゲーム内）
 

--- a/docs/minedojo_integration.md
+++ b/docs/minedojo_integration.md
@@ -1,0 +1,55 @@
+# MineDojo 連携ガイド
+
+Python エージェントから MineDojo のミッション/デモを参照する際の手順と、データ利用に関する注意事項をまとめます。
+
+## 1. ディレクトリ構成
+
+`MINEDOJO_DATASET_DIR` を指定した場合は、以下の構成で JSON ファイルを配置してください。
+
+```
+<MINEDOJO_DATASET_DIR>/
+  missions/
+    obtain_diamond.json
+    harvest_wheat.json
+    build_simple_house.json
+  demos/
+    obtain_diamond.json
+    harvest_wheat.json
+    build_simple_house.json
+```
+
+* `missions/*.json` … ミッションのメタ情報。`title`・`objective`・`tags` 等のキーを含めます。
+* `demos/*.json` … デモの配列を格納する JSON。`[{"id": ..., "summary": ..., "actions": [...]}, ...]` の形式を推奨します。
+* `actions` 配列は Mineflayer へそのまま転送可能な `{ "type": "moveTo", "args": {...} }` フォーマットを想定しています。過剰なデータは `python/services/minedojo_client.py` 側でフィルタリングされます。
+
+## 2. 環境変数
+
+| 変数名 | 用途 | 既定値 |
+| --- | --- | --- |
+| `MINEDOJO_API_BASE_URL` | MineDojo API のベース URL | `https://api.minedojo.org/v1` |
+| `MINEDOJO_API_KEY` | API 認証用トークン。未設定ならローカルデータセットのみ利用 | なし |
+| `MINEDOJO_DATASET_DIR` | ローカル JSON データセットのルートパス | なし |
+| `MINEDOJO_CACHE_DIR` | API 応答とデモをキャッシュするディレクトリ | `var/cache/minedojo` |
+| `MINEDOJO_REQUEST_TIMEOUT` | API リクエストのタイムアウト秒数 | `10.0` |
+
+## 3. データ利用ポリシー
+
+1. **ライセンス遵守**: MineDojo の公開データセットは学術研究用途を前提としています。商用利用や再配布を行う場合は、公式ライセンスに従って許諾を得てください。
+2. **機密情報の保護**: API 応答やデモ軌跡にはプレイヤー名・座標などの情報が含まれる場合があります。`var/cache/minedojo/` 以下のファイルは `.gitignore` に登録済みですが、ログやスクリーンショットにも不要な情報が残らないよう注意してください。
+3. **アクセス制御**: `MINEDOJO_API_KEY` は機密情報です。`.env` などの秘匿ファイルで管理し、共有リポジトリへコミットしないでください。CI で利用する場合はシークレット管理機構（GitHub Actions Secrets 等）を利用してください。
+4. **キャッシュの無害化**: 共有マシンで開発する場合は、不要になったキャッシュを `rm -rf var/cache/minedojo` で削除し、他メンバーが誤って過去データを使用しないようにしてください。
+5. **テレメトリ抑止**: テスト環境では `MINEDOJO_API_KEY` を空にし、ローカルデータセットのみで検証することを推奨します。これにより外部 API への不要なリクエストや利用規約違反を防げます。
+
+## 4. ワークフロー統合
+
+1. エージェントはタスク分類結果からカテゴリを決定し、`python/agent.py` の `_MINEDOJO_MISSION_BINDINGS` でミッション ID を解決します。
+2. `MineDojoClient` がキャッシュ→ローカル→API の順にミッション情報とデモを探索し、成功した場合は `Actions.play_vpt_actions` にデモを自動送信します。
+3. LLM プロンプトへはミッション概要とデモ要約が `minedojo_context` キーとして注入されます。反省ログや検出レポートと同様に `Memory` へ保存されるため、後続の再計画でも参照可能です。
+4. MineDojo から得た情報は `tests/integration/test_minedojo_adapter.py` で検証しており、スタブクライアントを差し込むことで外部サービスへアクセスせずに回帰テストを実行できます。
+
+## 5. トラブルシューティング
+
+* **API キー未設定時に警告が出る**: 仕様です。ローカルデータセットが利用可能であれば自動でフォールバックします。
+* **JSON の形式エラー**: `MineDojoClient` は例外をログへ出力し、失敗時はミッション/デモを返しません。テスト用に `python -m json.tool` でフォーマットを検証するか、`tests/integration/test_minedojo_adapter.py` を実行して構造を確認してください。
+* **Mineflayer へデモが届かない**: `Actions.play_vpt_actions` が存在しない環境では自動送信をスキップします。Mineflayer 実装側で同名コマンドをサポートしているか確認してください。
+

--- a/python/services/__init__.py
+++ b/python/services/__init__.py
@@ -13,6 +13,7 @@ from .building_service import (
     rollback_building_state,
 )
 from .vpt_controller import VPTController, VPTModelSpec
+from .minedojo_client import MineDojoClient, MineDojoDemonstration, MineDojoMission
 
 __all__ = [
     "BuildingCheckpoint",
@@ -26,4 +27,7 @@ __all__ = [
     "rollback_building_state",
     "VPTController",
     "VPTModelSpec",
+    "MineDojoClient",
+    "MineDojoMission",
+    "MineDojoDemonstration",
 ]

--- a/python/services/minedojo_client.py
+++ b/python/services/minedojo_client.py
@@ -1,0 +1,295 @@
+# -*- coding: utf-8 -*-
+"""MineDojo API やローカルデータセットからミッション情報を取得するクライアント。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import httpx
+
+from config import MineDojoConfig
+from utils import setup_logger
+
+
+@dataclass
+class MineDojoMission:
+    """LLM プロンプトへ差し込むためのミッション情報。"""
+
+    mission_id: str
+    title: str
+    objective: str
+    tags: Sequence[str] = field(default_factory=tuple)
+    source: str = "api"
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    def to_prompt_payload(self) -> Dict[str, Any]:
+        """プロンプトへ渡しやすい要約ペイロードを生成する。"""
+
+        return {
+            "mission_id": self.mission_id,
+            "title": self.title,
+            "objective": self.objective,
+            "tags": list(self.tags),
+            "source": self.source,
+        }
+
+
+@dataclass
+class MineDojoDemonstration:
+    """MineDojo のデモを Actions.play_vpt_actions と共有するための構造体。"""
+
+    demo_id: str
+    summary: str
+    actions: Sequence[Dict[str, Any]] = field(default_factory=tuple)
+    source: str = "api"
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    def to_metadata(self) -> Dict[str, Any]:
+        """Actions 側へ転送する際のメタデータを生成する。"""
+
+        payload = {
+            "demo_id": self.demo_id,
+            "summary": self.summary,
+            "source": self.source,
+        }
+        if "duration" in self.raw:
+            payload["duration"] = self.raw["duration"]
+        if "success" in self.raw:
+            payload["success"] = self.raw["success"]
+        return payload
+
+
+class MineDojoClient:
+    """MineDojo API とローカルデータセットを透過的に扱う薄いクライアント。"""
+
+    def __init__(self, config: MineDojoConfig, *, http_client: Optional[httpx.AsyncClient] = None) -> None:
+        # MineDojo 連携で参照するパラメータ群を保持し、メソッド毎に再利用する。
+        self._config = config
+        self._logger = setup_logger("services.minedojo")
+        self._http_client = http_client
+        self._mission_cache: Dict[str, MineDojoMission] = {}
+        self._demo_cache: Dict[str, List[MineDojoDemonstration]] = {}
+        self._cache_dir = Path(config.cache_dir)
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_lock = asyncio.Lock()
+
+    async def aclose(self) -> None:
+        """生成した HTTP クライアントを明示的に破棄する。"""
+
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def fetch_mission(self, mission_id: str) -> Optional[MineDojoMission]:
+        """ミッション ID に対応するメタ情報を取得する。"""
+
+        mission_key = mission_id.strip()
+        if not mission_key:
+            return None
+
+        cached = self._mission_cache.get(mission_key)
+        if cached:
+            return cached
+
+        payload = await self._read_cached_json(f"mission_{mission_key}.json")
+        source = "cache"
+        if payload is None:
+            payload = await self._load_local_dataset("missions", mission_key)
+            source = "dataset" if payload is not None else source
+        if payload is None:
+            payload = await self._request_json(f"/missions/{mission_key}")
+            source = "api" if payload is not None else source
+            if payload is not None:
+                await self._write_cache(f"mission_{mission_key}.json", payload)
+
+        if not isinstance(payload, dict):
+            return None
+
+        mission = self._parse_mission_payload(mission_key, payload, source)
+        self._mission_cache[mission_key] = mission
+        return mission
+
+    async def fetch_demonstrations(
+        self, mission_id: str, *, limit: int = 1
+    ) -> List[MineDojoDemonstration]:
+        """ミッションに紐づくデモを取得する。"""
+
+        mission_key = mission_id.strip()
+        if not mission_key:
+            return []
+
+        cached = self._demo_cache.get(mission_key)
+        if cached:
+            return cached[:limit]
+
+        payload = await self._read_cached_json(f"demo_{mission_key}.json")
+        source = "cache"
+        if payload is None:
+            payload = await self._load_local_dataset("demos", mission_key)
+            source = "dataset" if payload is not None else source
+        if payload is None:
+            endpoint = f"/missions/{mission_key}/demonstrations"
+            payload = await self._request_json(endpoint, params={"limit": limit})
+            source = "api" if payload is not None else source
+            if payload is not None:
+                await self._write_cache(f"demo_{mission_key}.json", payload)
+
+        demos = self._parse_demonstrations_payload(mission_key, payload, source)
+        self._demo_cache[mission_key] = demos
+        return demos[:limit]
+
+    async def _request_json(
+        self, path: str, *, params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Any]:
+        """MineDojo API から JSON を取得する汎用メソッド。"""
+
+        if not self._config.api_key:
+            self._logger.info("MineDojo API key is not configured; skipping remote request path=%s", path)
+            return None
+
+        client = await self._ensure_http_client()
+        headers = {"Authorization": f"Bearer {self._config.api_key}"}
+        try:
+            response = await client.get(path, headers=headers, params=params)
+        except httpx.HTTPError:
+            self._logger.exception("MineDojo API request failed path=%s", path)
+            return None
+
+        if response.status_code >= 400:
+            self._logger.warning(
+                "MineDojo API returned error status=%s path=%s body=%s",
+                response.status_code,
+                path,
+                response.text,
+            )
+            return None
+
+        try:
+            return response.json()
+        except ValueError:
+            self._logger.error("MineDojo API response JSON decode failed path=%s", path)
+            return None
+
+    async def _ensure_http_client(self) -> httpx.AsyncClient:
+        """httpx.AsyncClient を遅延生成し、再利用する。"""
+
+        if self._http_client is not None:
+            return self._http_client
+
+        timeout = httpx.Timeout(self._config.request_timeout)
+        self._http_client = httpx.AsyncClient(
+            base_url=self._config.api_base_url,
+            timeout=timeout,
+        )
+        return self._http_client
+
+    async def _read_cached_json(self, filename: str) -> Optional[Any]:
+        """キャッシュディレクトリから JSON を読み込む。"""
+
+        cache_path = self._cache_dir / filename
+        if not cache_path.exists():
+            return None
+
+        async with self._cache_lock:
+            try:
+                return json.loads(cache_path.read_text(encoding="utf-8"))
+            except Exception:
+                self._logger.exception("failed to read MineDojo cache file path=%s", cache_path)
+                return None
+
+    async def _write_cache(self, filename: str, payload: Any) -> None:
+        """取得した JSON をキャッシュへ書き出す。"""
+
+        cache_path = self._cache_dir / filename
+        async with self._cache_lock:
+            try:
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                cache_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+            except Exception:
+                self._logger.exception("failed to write MineDojo cache file path=%s", cache_path)
+
+    async def _load_local_dataset(self, subdir: str, mission_id: str) -> Optional[Any]:
+        """ローカルデータセットを参照できる場合はファイルから読み込む。"""
+
+        if not self._config.dataset_dir:
+            return None
+
+        dataset_path = Path(self._config.dataset_dir) / subdir / f"{mission_id}.json"
+        if not dataset_path.exists():
+            return None
+
+        try:
+            return json.loads(dataset_path.read_text(encoding="utf-8"))
+        except Exception:
+            self._logger.exception("failed to load MineDojo dataset path=%s", dataset_path)
+            return None
+
+    def _parse_mission_payload(
+        self, mission_id: str, payload: Dict[str, Any], source: str
+    ) -> MineDojoMission:
+        """ミッション JSON から必要項目だけ抽出する。"""
+
+        title = str(payload.get("title") or payload.get("name") or mission_id)
+        objective = str(payload.get("objective") or payload.get("description") or "")
+        tags_field = payload.get("tags")
+        if isinstance(tags_field, (list, tuple)):
+            tags = tuple(str(tag) for tag in tags_field if str(tag).strip())
+        else:
+            tags = ()
+        return MineDojoMission(
+            mission_id=mission_id,
+            title=title,
+            objective=objective,
+            tags=tags,
+            source=source,
+            raw=payload,
+        )
+
+    def _parse_demonstrations_payload(
+        self, mission_id: str, payload: Any, source: str
+    ) -> List[MineDojoDemonstration]:
+        """デモ JSON から実行に必要なアクション列を抽出する。"""
+
+        if isinstance(payload, dict) and "demos" in payload:
+            entries = payload.get("demos")
+        else:
+            entries = payload
+
+        if not isinstance(entries, list):
+            return []
+
+        demos: List[MineDojoDemonstration] = []
+        for index, item in enumerate(entries):
+            if not isinstance(item, dict):
+                continue
+            demo_id = str(item.get("id") or item.get("demo_id") or f"{mission_id}-{index}")
+            summary = str(item.get("summary") or item.get("description") or "")
+            actions_field = item.get("actions") or item.get("trajectory")
+            actions: Sequence[Dict[str, Any]] = []
+            if isinstance(actions_field, list):
+                normalized_actions: List[Dict[str, Any]] = []
+                for action in actions_field:
+                    if isinstance(action, dict):
+                        normalized_actions.append(action)
+                actions = normalized_actions
+            demos.append(
+                MineDojoDemonstration(
+                    demo_id=demo_id,
+                    summary=summary,
+                    actions=actions,
+                    source=source,
+                    raw=item,
+                )
+            )
+        return demos
+
+
+__all__ = [
+    "MineDojoClient",
+    "MineDojoMission",
+    "MineDojoDemonstration",
+]

--- a/tests/integration/test_minedojo_adapter.py
+++ b/tests/integration/test_minedojo_adapter.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock
+
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_DIR = PROJECT_ROOT / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_minedojo_context_is_injected_into_actions_and_memory() -> None:
+    pytest.importorskip("langgraph")
+
+    from agent import AgentOrchestrator  # type: ignore  # noqa: E402
+    from config import AgentConfig, MineDojoConfig  # type: ignore  # noqa: E402
+    from memory import Memory  # type: ignore  # noqa: E402
+    from services.minedojo_client import (  # type: ignore  # noqa: E402
+        MineDojoDemonstration,
+        MineDojoMission,
+    )
+
+    class StubActions:
+        """MineDojo デモの送信結果を記録する最小限のスタブ。"""
+
+        def __init__(self) -> None:
+            self.played: List[Dict[str, Any]] = []
+
+        async def play_vpt_actions(
+            self, actions: List[Dict[str, Any]], *, metadata: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            record = {"actions": actions, "metadata": metadata or {}}
+            self.played.append(record)
+            return {"ok": True, "data": record}
+
+        async def say(self, text: str) -> Dict[str, Any]:  # pragma: no cover - helper for safety
+            return {"ok": True, "data": {"text": text}}
+
+    class StubMineDojoClient:
+        """固定レスポンスでミッションとデモを返すテスト用クライアント。"""
+
+        async def fetch_mission(self, mission_id: str) -> MineDojoMission:
+            return MineDojoMission(
+                mission_id=mission_id,
+                title="ダイヤモンド採掘トレーニング",
+                objective="安全にダイヤモンドを掘り当てる",
+                tags=("mining", "safety"),
+                source="test",
+                raw={"difficulty": "medium"},
+            )
+
+        async def fetch_demonstrations(
+            self, mission_id: str, *, limit: int = 1
+        ) -> List[MineDojoDemonstration]:
+            return [
+                MineDojoDemonstration(
+                    demo_id="demo-1",
+                    summary="地下渓谷での採掘手順",
+                    actions=[{"type": "moveTo", "args": {"x": 1, "y": 64, "z": -3}}],
+                    source="test",
+                    raw={"duration": 12.3, "success": True},
+                )
+            ]
+
+    class StubSkillRepository:
+        """スキル検索を無効化する簡易スタブ。"""
+
+        async def match_skill(self, text: str, *, category: Optional[str] = None) -> None:
+            return None
+
+        async def record_usage(self, skill_id: str, *, success: bool) -> None:  # pragma: no cover - not used
+            return None
+
+    config = AgentConfig(
+        ws_url="ws://127.0.0.1:8765",
+        agent_host="0.0.0.0",
+        agent_port=9000,
+        default_move_target=(0, 64, 0),
+        default_move_target_raw="0,64,0",
+        skill_library_path="/tmp/skills.json",
+        minedojo=MineDojoConfig(
+            api_base_url="https://example.org",
+            api_key=None,
+            dataset_dir=None,
+            cache_dir="/tmp/minedojo-cache",
+            request_timeout=5.0,
+        ),
+    )
+    actions = StubActions()
+    memory = Memory()
+    orchestrator = AgentOrchestrator(
+        actions,
+        memory,
+        skill_repository=StubSkillRepository(),
+        config=config,
+        minedojo_client=StubMineDojoClient(),
+    )
+    orchestrator._action_graph.run = AsyncMock(return_value=(True, None, None))  # type: ignore[assignment]
+
+    handled, _, failure = await orchestrator._handle_action_task(
+        "mine",
+        "ダイヤモンドを採掘する",
+        last_target_coords=None,
+        backlog=[],
+    )
+
+    assert handled is True
+    assert failure is None
+
+    assert orchestrator.memory.get("minedojo_context") == {
+        "mission": {
+            "mission_id": "obtain_diamond",
+            "title": "ダイヤモンド採掘トレーニング",
+            "objective": "安全にダイヤモンドを掘り当てる",
+            "tags": ["mining", "safety"],
+            "source": "test",
+        },
+        "demonstrations": [
+            {
+                "demo_id": "demo-1",
+                "summary": "地下渓谷での採掘手順",
+                "action_types": ["moveTo"],
+                "action_count": 1,
+            }
+        ],
+    }
+
+    assert len(actions.played) == 1
+    assert actions.played[0]["metadata"]["mission_id"] == "obtain_diamond"
+    assert actions.played[0]["metadata"]["demo_id"] == "demo-1"
+    assert actions.played[0]["actions"] == [{"type": "moveTo", "args": {"x": 1, "y": 64, "z": -3}}]

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -18,6 +18,9 @@ def test_load_agent_config_returns_defaults() -> None:
     assert config.agent_host == "0.0.0.0"
     assert config.agent_port == 9000
     assert config.default_move_target == (0, 64, 0)
+    assert config.minedojo.api_base_url == "https://api.minedojo.org/v1"
+    assert config.minedojo.cache_dir == "var/cache/minedojo"
+    assert config.minedojo.api_key is None
 
 
 def test_load_agent_config_emits_warning_on_invalid_port() -> None:


### PR DESCRIPTION
1. `python/services/minedojo_client.py`（新規）を追加し、MineDojo API やローカルデータセットからミッション情報/デモを取得できるようにする。必要な API キーやキャッシュ設定を `python/config.py` に追加する。
2. `python/agent.py` のタスク分類処理に MineDojo ミッション ID を紐付ける層を追加し、該当シナリオでは取得したデモを `Actions` 実行や LLM プロンプトへ自動注入する。
3. 連携手順とデータ利用ポリシーを `README.md`・`docs/` に追記し、`tests/integration/test_minedojo_adapter.py`（新規）でクライアントとオーケストレーションの結合テストを整備する。

close #53 #47 

---

## 概要
- MineDojo クライアントを追加し、API/ローカルデータセット/キャッシュ経由でミッション情報とデモを取得できるようにしました
- タスク分類結果からミッション ID を推定してデモを Actions と LLM プロンプトへ注入し、設定値・ドキュメント・テストを更新しました
- Git 応答に含めないべきキャッシュ/データセットを .gitignore へ追加し、MineDojo 連携手順とデータ利用ポリシーを整理しました

## テスト
- `pytest tests/test_agent_config.py tests/integration/test_minedojo_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68f4d83672c8832c96f2d85a119c39f6