### PR TITLE
Mineflayer 制御ログ初期化順序の是正

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Node 側のボット実装は TypeScript 化しており、`npm start` を実行
 Mineflayer 起動時の環境変数は `node-bot/runtime/config.ts` へ集約しており、Docker 実行時の `MC_HOST` 補正や `MC_VERSION` のフォールバック、`MOVE_GOAL_TOLERANCE` の上下限チェックを一括で行います。
 設定変更のテストは `node-bot/tests/config.test.ts` を実行すると安全に回帰確認できます。
 
+制御ループの設定値は `node-bot/bot.ts` の冒頭で初期化してからログへ出力するよう整理しました。`npm start` で Mineflayer ボットを再起動し、
+標準出力に `mode=... tick=... maxSeq=...` が表示されクラッシュが発生しないことを確認してください。未初期化定数を参照した際の例外はこの変更で解消されます。
+
 2025 年 10 月のアップデートでは `node-bot/runtime/roles.ts` に役割カタログを追加し、`setAgentRole` コマンドで LangGraph から防衛/補給/偵察などのロールへ即座に切り替えられるようになりました。Mineflayer から `agentEvent` チャネル経由で位置・体力・役割のスナップショットを Python 側へ push するため、イベント駆動で共有メモリが更新されます。
 
 `bot.ts` には `gatherStatus` WebSocket コマンドを実装しており、Python エージェントが現在位置・インベントリ・体力/満腹度と掘削許可のスナップショットを即座に取得できます。Mineflayer の `canDig` 設定やゲームモードから地下採掘の可否を判定し、所持ツルハシのエンチャント情報と併せて JSON で返すため、チャット経由で逐一質問せずとも自律的な計画を立てられます。

--- a/node-bot/bot.ts
+++ b/node-bot/bot.ts
@@ -38,6 +38,11 @@ for (const warning of runtimeWarnings) {
   console.warn(`[Config] ${warning}`);
 }
 
+// Mineflayer 制御ループの設定値はログ出力より前に初期化し、未定義参照によるクラッシュを防ぐ。
+const CONTROL_MODE = runtimeConfig.control.mode;
+const VPT_TICK_INTERVAL_MS = runtimeConfig.control.vpt.tickIntervalMs;
+const VPT_MAX_SEQUENCE_LENGTH = runtimeConfig.control.vpt.maxSequenceLength;
+
 console.log(`[Control] mode=${CONTROL_MODE} tick=${VPT_TICK_INTERVAL_MS}ms maxSeq=${VPT_MAX_SEQUENCE_LENGTH}`);
 
 const MC_VERSION = runtimeConfig.minecraft.version;
@@ -52,9 +57,6 @@ const AGENT_WS_URL = runtimeConfig.agentBridge.url;
 const MOVE_GOAL_TOLERANCE = runtimeConfig.moveGoalTolerance.tolerance;
 const MINING_APPROACH_TOLERANCE = 1;
 const SKILL_HISTORY_PATH = runtimeConfig.skills.historyPath;
-const CONTROL_MODE = runtimeConfig.control.mode;
-const VPT_TICK_INTERVAL_MS = runtimeConfig.control.vpt.tickIntervalMs;
-const VPT_MAX_SEQUENCE_LENGTH = runtimeConfig.control.vpt.maxSequenceLength;
 
 // ---- 型定義 ----
 // 受信するコマンド種別のユニオン。追加実装時はここを拡張する。


### PR DESCRIPTION
1. `node-bot/bot.ts` を開き、`CONTROL_MODE`・`VPT_TICK_INTERVAL_MS`・`VPT_MAX_SEQUENCE_LENGTH` の `const` 宣言行（`runtimeConfig.control` から値を受け取る箇所）を確認する。
2. これら3つの `const` 宣言を、現在の `console.log`（制御パラメータを出力する行）よりも前に移動するか、代わりにログ呼び出し自体を定数宣言の直後へ移動する。
3. 変更後、`console.log` が初期化済みの値を参照していることを確認し、Mineflayer ボットを再起動してクラッシュが解消されたことを手元で検証する。
4. 影響範囲を記録するため、変更内容とテスト結果をドキュメント化（必要に応じて README の起動手順に追記）し、レビュアーへ共有する。

---

## 概要
- Mineflayer ボット起動時に制御設定定数をログ出力より先に初期化し、未定義参照クラッシュを防止
- 制御ループ設定の確認手順を README に追記し、再起動検証の観点を共有

## テスト
- 未実施（Mineflayer ボットの再起動はローカル接続先のサーバーが必要なため）

------
https://chatgpt.com/codex/tasks/task_e_68f4de6d5e84832cad5709c8d4d20307