### PR TITLE
Mineflayer未登録スキル時のフォールバック処理を改善

### DIFF
--- a/python/agent_orchestrator.py
+++ b/python/agent_orchestrator.py
@@ -181,6 +181,10 @@ class ActionGraph:
                     return {"skill_status": "none"}
                 handled, failure_detail = await orchestrator._execute_skill_match(match, step)  # type: ignore[attr-defined]
                 status = "handled" if handled else "failed"
+                if not handled and failure_detail is None:
+                    # Mineflayer 側で未登録スキルだった場合は skill_status を none に戻し、
+                    # LangGraph が通常の装備・採掘ヒューリスティックへ遷移できるようにする。
+                    status = "none"
                 return {
                     "handled": handled,
                     "failure_detail": failure_detail,

--- a/tests/test_agent_mine.py
+++ b/tests/test_agent_mine.py
@@ -19,6 +19,7 @@ if str(PYTHON_DIR) not in sys.path:
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
+from skills import SkillMatch, SkillNode  # type: ignore  # noqa: E402
 
 
 class DummyActions:
@@ -154,3 +155,90 @@ def test_mine_continues_when_pickaxe_missing(
         "deepslate_redstone_ore",
     ]
     assert actions.equip_calls == []
+
+
+class SkillFallbackActions:
+    """登録外スキル応答を模倣し、フォールバック処理を検証するためのスタブ。"""
+
+    def __init__(self) -> None:
+        self.mine_calls: List[Dict[str, Any]] = []
+        self.skill_invocations: List[str] = []
+
+    async def say(self, text: str) -> Dict[str, Any]:
+        return {"ok": True, "echo": text}
+
+    async def invoke_skill(self, skill_id: str, *, context: str) -> Dict[str, Any]:
+        self.skill_invocations.append(skill_id)
+        return {"ok": False, "error": f"Skill {skill_id} is not registered"}
+
+    async def mine_ores(
+        self,
+        targets: List[str],
+        *,
+        scan_radius: int,
+        max_targets: int,
+    ) -> Dict[str, Any]:
+        self.mine_calls.append(
+            {
+                "targets": list(targets),
+                "scan_radius": scan_radius,
+                "max_targets": max_targets,
+            }
+        )
+        return {"ok": True}
+
+    async def equip_item(
+        self,
+        *,
+        tool_type: Optional[str] = None,
+        item_name: Optional[str] = None,
+        destination: str = "hand",
+    ) -> Dict[str, Any]:
+        return {"ok": True, "tool_type": tool_type, "item_name": item_name, "destination": destination}
+
+
+class SkillRepositoryStub:
+    """SkillMatch を固定で提供し、record_usage 呼び出しを観測するテスト専用リポジトリ。"""
+
+    def __init__(self, match: SkillMatch) -> None:
+        self._match = match
+        self.record_usage_calls: List[Tuple[str, bool]] = []
+
+    async def match_skill(self, step: str, *, category: str) -> SkillMatch:
+        return self._match
+
+    async def record_usage(self, skill_id: str, *, success: bool) -> None:
+        self.record_usage_calls.append((skill_id, success))
+
+
+def test_unregistered_skill_falls_back_to_mining_route() -> None:
+    """Mineflayer 側で未登録エラーが返っても採掘ヒューリスティックへ進むことを確認する。"""
+
+    actions = SkillFallbackActions()
+    skill_node = SkillNode(
+        identifier="skill.mine.dummy",
+        title="模擬採掘スキル",
+        description="テスト用のダミースキル",
+        categories=("mine",),
+    )
+    match = SkillMatch(skill=skill_node, score=1.0)
+    repo = SkillRepositoryStub(match)
+    orchestrator = AgentOrchestrator(actions, Memory(), skill_repository=repo)
+
+    backlog: List[Dict[str, str]] = []
+
+    async def runner() -> Tuple[bool, Optional[Tuple[int, int, int]], Optional[str]]:
+        return await orchestrator._handle_action_task(
+            "mine",
+            "登録済みスキルが見つからない場合も採掘して",
+            last_target_coords=None,
+            backlog=backlog,
+        )
+
+    handled, _, failure_detail = asyncio.run(runner())
+
+    assert handled is True
+    assert failure_detail is None
+    assert backlog == []
+    assert len(actions.mine_calls) == 1
+    assert repo.record_usage_calls == [(skill_node.identifier, False)]


### PR DESCRIPTION
1. `python/agent.py` の `_execute_skill_match` を更新し、Mineflayer からのレスポンスで `resp.get("error")` が `is not registered` を含む場合は INFO ログを残したうえで `(False, None)` を返すよう分岐を追加し、障壁詳細を返さないことでフォールバックを許容する。
2. `python/agent_orchestrator.py` の `seek_skill` ノードで、`handled` が `False` かつ `failure_detail` が `None` のケースでは `skill_status` を `'none'` に上書きして後続ノード（装備・採掘ヒューリスティック）へ処理を進めるようにする。
3. 上記変更を検証するテストを `tests/` 配下へ追加し、`Skill ${id} is not registered` 応答をモックしたときに採掘ルートへフォールバックできること、および `SkillRepository.record_usage(..., success=False)` が呼び出されることを確認する。

---


## 概要
- Mineflayer から "is not registered" が返った際に INFO ログのみを残してフォールバックを許容するよう `_execute_skill_match` を拡張
- LangGraph の `seek_skill` ノードで未登録スキル失敗時は `skill_status` を `none` に戻し、装備・採掘ヒューリスティックへ遷移できるように調整
- 未登録スキル応答で採掘ルートへ進み、失敗記録が残ることを確認するシナリオテストを追加

## テスト
- `pytest tests/test_agent_mine.py::test_unregistered_skill_falls_back_to_mining_route`


------
https://chatgpt.com/codex/tasks/task_e_68f4f1786d18832c92e2f53ca86fd642