### PR TITLE
インベントリ再取得による装備処理の安全化

### DIFF
--- a/tests/test_agent_equip.py
+++ b/tests/test_agent_equip.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
+
+import copy
 
 import pytest
 
@@ -24,14 +26,45 @@ from memory import Memory  # type: ignore  # noqa: E402
 class DummyActions:
     """AgentOrchestrator から呼び出されるアクションを記録するスタブ。"""
 
-    def __init__(self) -> None:
+    def __init__(self, *, inventory_data: Optional[Dict[str, Any]] = None) -> None:
         self.equip_calls: List[Dict[str, Optional[str]]] = []
+        self.say_messages: List[str] = []
+        # gather_status("inventory") の戻り値を差し替えられるようにすることで、
+        # 装備テストがさまざまな在庫状況を簡単に再現できる。
+        default_inventory = {
+            "formatted": "所持品は 1 種類（ツルハシ 1 本）を確認しました。",
+            "items": [
+                {
+                    "slot": 0,
+                    "name": "iron_pickaxe",
+                    "displayName": "Iron Pickaxe",
+                    "count": 1,
+                    "enchantments": [],
+                }
+            ],
+            "pickaxes": [
+                {
+                    "slot": 0,
+                    "name": "iron_pickaxe",
+                    "displayName": "Iron Pickaxe",
+                    "count": 1,
+                    "enchantments": [],
+                }
+            ],
+        }
+        self._inventory_snapshot: Dict[str, Any] = inventory_data or default_inventory
 
     async def say(self, text: str) -> Dict[str, bool]:
+        self.say_messages.append(text)
         return {"ok": True}
 
     async def move_to(self, x: int, y: int, z: int) -> Dict[str, bool]:
         return {"ok": True}
+
+    async def gather_status(self, kind: str) -> Dict[str, Any]:
+        if kind != "inventory":
+            return {"ok": False, "error": f"unsupported status kind: {kind}"}
+        return {"ok": True, "data": copy.deepcopy(self._inventory_snapshot)}
 
     async def equip_item(
         self,
@@ -95,3 +128,44 @@ def test_handle_action_task_dispatches_equip(orchestrator: AgentOrchestrator) ->
     assert dummy_actions.equip_calls == [
         {"tool_type": "pickaxe", "item_name": None, "destination": "hand"}
     ]
+
+
+def test_handle_equip_reports_barrier_when_pickaxe_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """在庫にピッケルがない場合は装備コマンドを送信せず障壁通知する。"""
+
+    inventory_data = {
+        "formatted": "所持品は空です。",
+        "items": [],
+        "pickaxes": [],
+    }
+    actions = DummyActions(inventory_data=inventory_data)
+    memory = Memory()
+    orchestrator = AgentOrchestrator(actions, memory)
+
+    async def fake_barrier(step: str, reason: str, context: Dict[str, Any]) -> str:
+        return f"障壁: {step} / {reason}"
+
+    monkeypatch.setattr("agent.compose_barrier_notification", fake_barrier)
+
+    backlog: List[Dict[str, str]] = []
+
+    async def runner() -> None:
+        handled, _, failure = await orchestrator._handle_action_task(
+            "equip",
+            "採掘用のツルハシを装備して",
+            last_target_coords=None,
+            backlog=backlog,
+        )
+
+        assert handled is False
+        assert failure is not None
+        assert "装備" in failure
+
+    asyncio.run(runner())
+
+    assert backlog == []
+    assert actions.equip_calls == []
+    assert actions.say_messages, "障壁メッセージが送信されていません"
+    assert "ツルハシ" in actions.say_messages[0]


### PR DESCRIPTION
1. `python/agent_orchestrator.py` の `_ActionState` 周辺にインベントリ再取得ヘルパー（例: `_refresh_inventory_snapshot`）を追加し、`actions.gather_status("inventory")` のレスポンスを `memory` の `inventory` / `inventory_detail` に反映する実装を追加する。
2. `handle_equip` 内でヘルパーを呼び出し、指定された `tool_type` や `item_name` がインベントリ詳細に存在するかをチェックするロジックを実装し、存在しない場合は `equip_item` を送信せず `_report_execution_barrier` で不足を通知する。
3. 既存のテストハーネスを利用し、インベントリにピッケルが無いケースで `handle_equip` が装備コマンドを送信せずバリア報告を返すことを確認するユニットテストを追加する。

---

## 概要
- LangGraph の equip ノードで装備前にインベントリを再取得し、取得失敗時や所持品不足時はバリアを報告するようにしました
- gather_status("inventory") の結果をメモリへ反映するヘルパーを追加し、在庫確認が分かりやすくなるコメントを補いました
- ピッケル未所持のケースで装備コマンドを送信しないことを検証するユニットテストを追加しました

## テスト
- `pytest tests/test_agent_equip.py`


------
https://chatgpt.com/codex/tasks/task_e_68f50a576454832ca3d33b12803827ab