### PR TITLE
装備失敗時の在庫同期と再計画コンテキストの改善

### DIFF
--- a/python/agent.py
+++ b/python/agent.py
@@ -1013,6 +1013,11 @@ class AgentOrchestrator:
             return
 
         context = self._build_context_snapshot()
+        inventory_detail = self.memory.get("inventory_detail")
+        # 所持品詳細を replan コンテキストへ含めることで、直前の装備失敗で
+        # ツルハシが不足しているなどの状況を LLM へ明確に伝えられる。
+        if inventory_detail is not None:
+            context["inventory_detail"] = inventory_detail
         remaining_text = "、".join(remaining_steps) if remaining_steps else ""
         replan_instruction = (
             f"手順「{failed_step}」の実行に失敗しました（{failure_reason}）。"


### PR DESCRIPTION
1. `handle_equip` で Mineflayer から「Requested item is not available in inventory」が返却された分岐に、直後のインベントリ再取得（`gather_status("inventory")`）と `memory` 更新、及び不足アイテムを示す `_report_execution_barrier` 呼び出しを追加して計画を明確に止める。
2. `_request_replan` に渡すコンテキストへ最新の `inventory_detail` を含め、ピッケル未所持が明示されるよう `memory` の該当キーをクリアまたは更新する処理を実装する。
3. 新しい制御フローをカバーする回帰テスト（装備失敗 → インベントリ更新 → バリア通知 → リプラン生成）のモックテストを `tests` 配下に追加し、繰り返しステップが抑制されることを検証する。

---

## 概要
- Mineflayer から装備対象欠品が返却された際に所持品を再取得し、メモリ更新と障壁通知で処理を停止するようにしました。
- 再計画要求に最新の inventory_detail を含め、在庫不足の状況が LLM に伝わるよう改善しました。
- 装備失敗から再計画までの流れを検証するモックテストを追加し、繰り返し実行の抑制を確認しました。

## テスト
- `pytest tests/test_agent_replan.py`


------
https://chatgpt.com/codex/tasks/task_e_68f50fb9e38c832cbebb13b4f4ef0575