### PR TITLE
アクション送信のバリデーションと構造化ログ整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pnpm-debug.log*
 *.log
 logs/
 python/logs/
+var/logs/
 
 # Python artifacts and virtual environments
 __pycache__/

--- a/node-bot/commands.md
+++ b/node-bot/commands.md
@@ -3,5 +3,9 @@
 - chat: `{ "type": "chat", "args": { "text": "こんにちは" } }`
 - moveTo: `{ "type": "moveTo", "args": { "x": 100, "y": 64, "z": -30 } }`
 - equipItem: `{ "type": "equipItem", "args": { "toolType": "pickaxe", "destination": "hand" } }`
-- （今後追加）dig / place / follow / attack / craft / scan 等
+- mineBlocks: `{ "type": "mineBlocks", "args": { "positions": [{"x":1,"y":64,"z":-3}] } }`
+- placeBlock: `{ "type": "placeBlock", "args": { "block": "oak_planks", "position": {"x":2,"y":65,"z":5}, "face": "north", "sneak": true } }`
+- followPlayer: `{ "type": "followPlayer", "args": { "target": "Taishi", "stopDistance": 2, "maintainLineOfSight": true } }`
+- attackEntity: `{ "type": "attackEntity", "args": { "target": "zombie", "mode": "melee", "chaseDistance": 6 } }`
+- craftItem: `{ "type": "craftItem", "args": { "item": "oak_planks", "amount": 3, "useCraftingTable": false } }`
 - mineOre: `{ "type": "mineOre", "args": { "ores": ["redstone_ore"], "scanRadius": 12, "maxTargets": 3 } }`

--- a/tests/test_actions_payloads.py
+++ b/tests/test_actions_payloads.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_DIR = PROJECT_ROOT / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+from actions import ActionValidationError, Actions  # type: ignore  # noqa: E402
+
+
+class RecordingBridge:
+    """テスト用に送信内容を記録する簡易 WebSocket ブリッジ。"""
+
+    def __init__(self, response: Dict[str, Any] | None = None) -> None:
+        self.sent: List[Dict[str, Any]] = []
+        self.response = response or {"ok": True, "marker": "test"}
+
+    async def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:  # noqa: D401 - テスト用スタブ
+        self.sent.append(payload)
+        return self.response | {"echo": payload}
+
+
+@pytest.mark.anyio
+async def test_mine_blocks_payload() -> None:
+    bridge = RecordingBridge()
+    actions = Actions(bridge)
+
+    result = await actions.mine_blocks([{"x": 1, "y": 64, "z": -3}])
+
+    assert bridge.sent[-1] == {
+        "type": "mineBlocks",
+        "args": {"positions": [{"x": 1, "y": 64, "z": -3}]},
+    }
+    assert result["ok"] is True
+
+
+@pytest.mark.anyio
+async def test_place_block_payload_with_face() -> None:
+    bridge = RecordingBridge()
+    actions = Actions(bridge)
+
+    await actions.place_block("oak_planks", {"x": 2, "y": 65, "z": 5}, face="north", sneak=True)
+
+    assert bridge.sent[-1] == {
+        "type": "placeBlock",
+        "args": {
+            "block": "oak_planks",
+            "position": {"x": 2, "y": 65, "z": 5},
+            "sneak": True,
+            "face": "north",
+        },
+    }
+
+
+@pytest.mark.anyio
+async def test_follow_player_payload() -> None:
+    bridge = RecordingBridge()
+    actions = Actions(bridge)
+
+    await actions.follow_player("Taishi", stop_distance=4, maintain_line_of_sight=False)
+
+    assert bridge.sent[-1] == {
+        "type": "followPlayer",
+        "args": {"target": "Taishi", "stopDistance": 4, "maintainLineOfSight": False},
+    }
+
+
+@pytest.mark.anyio
+async def test_attack_entity_mode_validation() -> None:
+    bridge = RecordingBridge()
+    actions = Actions(bridge)
+
+    with pytest.raises(ActionValidationError):
+        await actions.attack_entity("zombie", mode="invalid")
+
+
+@pytest.mark.anyio
+async def test_craft_item_payload() -> None:
+    bridge = RecordingBridge()
+    actions = Actions(bridge)
+
+    await actions.craft_item("oak_planks", amount=3, use_crafting_table=False)
+
+    assert bridge.sent[-1] == {
+        "type": "craftItem",
+        "args": {"item": "oak_planks", "amount": 3, "useCraftingTable": False},
+    }
+
+
+@pytest.mark.anyio
+async def test_dispatch_outputs_structured_log(caplog: pytest.LogCaptureFixture) -> None:
+    bridge = RecordingBridge()
+    actions = Actions(bridge)
+
+    with caplog.at_level(logging.INFO, logger="actions"):
+        await actions.say("進捗ログ")
+
+    # 進捗と完了の両方が出力されることを期待する。
+    progress = [record for record in caplog.records if getattr(record, "event_level", "") == "progress"]
+    completed = [record for record in caplog.records if getattr(record, "event_level", "") == "success"]
+    assert progress, "dispatch prepared ログが出力されていません"
+    assert completed, "dispatch completed ログが出力されていません"
+
+
+@pytest.mark.anyio
+async def test_validate_positions_rejects_empty() -> None:
+    bridge = RecordingBridge()
+    actions = Actions(bridge)
+
+    with pytest.raises(ActionValidationError):
+        await actions.mine_blocks([])


### PR DESCRIPTION
## 概要
- python/actions.py に採掘・設置・追従・戦闘・クラフトの WebSocket コマンド生成と入力バリデーションを追加し、dispatch 共通処理で構造化ログを出力するようにしました。
- Node 側のコマンド一覧および README に新しいアクションとチャット→内部コマンド対応表を追記し、payload スキーマを共有できるようにしました。
- アクションのペイロード生成とエラー時の挙動を確認するユニットテストを追加し、ログディレクトリの秘匿情報流出を防ぐため .gitignore を補強しました。

## テスト
- python -m pytest tests/test_actions_payloads.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b22e77724832c9ba11ec7b20389b0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds validated action commands with structured logging in `python/actions.py`, updates command schemas/docs, and adds unit tests.
> 
> - **Python**:
>   - **Actions API**: Add `place_block`, `follow_player`, `attack_entity`, `craft_item` plus validation helpers (`ActionValidationError`, `_require_position(s)`, `_require_non_empty_text`).
>   - **Existing commands**: Tighten payload validation for `say`, `move_to`, `mine_blocks`, `place_torch`, `mine_ores` (type/empty checks, int coercion).
>   - **Dispatch**: Rework `_dispatch` to emit structured logs (`event_level=progress/success/fault`), include `command_id`, payload/response, duration; add exception logging.
> - **Docs**:
>   - `README.md`: Add chat→command mapping with payload examples and logging behavior.
>   - `node-bot/commands.md`: Document new commands: `mineBlocks`, `placeBlock`, `followPlayer`, `attackEntity`, `craftItem`.
> - **Tests**:
>   - `tests/test_actions_payloads.py`: Verify payloads for new/updated commands, validation errors, and structured log emission.
> - **Repo hygiene**:
>   - `.gitignore`: Ignore `var/logs/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1666d3385d2a98e1cc3fc7121bde4f2cf07e8a47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->