### PR TITLE
BotBridgeのタイムアウト/リトライ強化と通知フックの追加

### DIFF
--- a/python/bridge_ws.py
+++ b/python/bridge_ws.py
@@ -1,26 +1,113 @@
 # -*- coding: utf-8 -*-
 import asyncio
 import json
+import logging
 import os
+from typing import Any, Awaitable, Callable, Dict, Optional
+
 import websockets
-from typing import Any, Dict
-from utils import setup_logger
+
+from utils import log_structured_event, setup_logger
 
 logger = setup_logger("bridge")
 
 class BotBridge:
     """Python→Node WebSocket ブリッジ（単純な送信ユーティリティ）"""
-    def __init__(self, ws_url: str | None = None) -> None:
+
+    def __init__(
+        self,
+        ws_url: str | None = None,
+        *,
+        connect_timeout: float = 5.0,
+        send_timeout: float = 3.0,
+        recv_timeout: float = 5.0,
+        max_retries: int = 4,
+        backoff_base: float = 1.0,
+    ) -> None:
         # Docker Compose 実行時はサービス名でルーティングできるよう、node-bot ホストを既定とする。
         self.ws_url = ws_url or os.getenv("WS_URL", "ws://node-bot:8765")
+        # タイムアウトとリトライ設定を明示して、デッドロックや無限待機を避ける。
+        self.connect_timeout = connect_timeout
+        self.send_timeout = send_timeout
+        self.recv_timeout = recv_timeout
+        self.max_retries = max(1, max_retries)
+        self.backoff_base = backoff_base
 
-    async def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        # 送信内容を INFO レベルで記録し、チャット指示などが確実に Python 側から発行されたことを追跡する。
+    async def send(
+        self,
+        payload: Dict[str, Any],
+        *,
+        on_retry: Optional[Callable[[int, str], Awaitable[None]]] = None,
+        on_give_up: Optional[Callable[[int, str], Awaitable[None]]] = None,
+    ) -> Dict[str, Any]:
+        """WebSocket 送信を行い、接続/送信/受信ごとにタイムアウトと例外を区別する。
+
+        on_retry/on_give_up を通じて呼び出し元（Actions など）が Mineflayer や
+        ユーザーへ再試行/断念の通知を転送できるフックを提供する。
+        """
+
         logger.info(f"WS send: {payload}")
-        async with websockets.connect(self.ws_url) as ws:
-            await ws.send(json.dumps(payload, ensure_ascii=False))
-            resp = await ws.recv()
-            # Node 側から返ってきたレスポンスも INFO レベルで記録して、
-            # 実行成否やエラーメッセージが即座に把握できるようにする。
-            logger.info(f"WS recv: {resp}")
-            return json.loads(resp)
+        for attempt in range(1, self.max_retries + 1):
+            stage = "connect"
+            try:
+                async with websockets.connect(
+                    self.ws_url, open_timeout=self.connect_timeout
+                ) as ws:
+                    stage = "send"
+                    await asyncio.wait_for(
+                        ws.send(json.dumps(payload, ensure_ascii=False)),
+                        timeout=self.send_timeout,
+                    )
+                    stage = "recv"
+                    resp = await asyncio.wait_for(ws.recv(), timeout=self.recv_timeout)
+                    logger.info(f"WS recv: {resp}")
+                    return json.loads(resp)
+            except Exception as error:  # noqa: BLE001 - 失敗種別ごとに判定するため広く捕捉
+                error_type = self._classify_error(stage, error)
+                is_connect_failure = stage == "connect"
+                should_retry = is_connect_failure and attempt < self.max_retries
+                event_level = "retry" if should_retry else "fault"
+                log_structured_event(
+                    logger,
+                    "WS communication failed",
+                    level=logging.WARNING if should_retry else logging.ERROR,
+                    event_level=event_level,
+                    context={
+                        "stage": stage,
+                        "attempt": attempt,
+                        "max_retries": self.max_retries,
+                        "payload": payload,
+                        "error_type": error_type,
+                    },
+                    exc_info=error,
+                )
+                if should_retry:
+                    if on_retry:
+                        await on_retry(attempt, error_type)
+                    await asyncio.sleep(self._compute_backoff(attempt))
+                    continue
+
+                if on_give_up:
+                    await on_give_up(attempt - 1, error_type)
+                return {
+                    "ok": False,
+                    "error": error_type,
+                    "retries": attempt - 1,
+                    "message": str(error),
+                }
+
+    def _classify_error(self, stage: str, error: Exception) -> str:
+        """例外内容から段階別のエラー種別をテキストで返す。"""
+
+        if isinstance(error, asyncio.TimeoutError):
+            return f"{stage}_timeout"
+        if isinstance(error, ConnectionRefusedError):
+            return "connect_refused"
+        if isinstance(error, OSError):
+            return f"{stage}_os_error"
+        return f"{stage}_error"
+
+    def _compute_backoff(self, attempt: int) -> float:
+        """指数バックオフの遅延を計算する。"""
+
+        return min(self.backoff_base * (2 ** (attempt - 1)), 8.0)

--- a/tests/test_actions_payloads.py
+++ b/tests/test_actions_payloads.py
@@ -22,7 +22,7 @@ class RecordingBridge:
         self.sent: List[Dict[str, Any]] = []
         self.response = response or {"ok": True, "marker": "test"}
 
-    async def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:  # noqa: D401 - テスト用スタブ
+    async def send(self, payload: Dict[str, Any], **_: Any) -> Dict[str, Any]:  # noqa: D401 - テスト用スタブ
         self.sent.append(payload)
         return self.response | {"echo": payload}
 

--- a/tests/test_bridge_ws.py
+++ b/tests/test_bridge_ws.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_DIR = PROJECT_ROOT / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+import bridge_ws  # noqa: E402  # isort:skip
+from bridge_ws import BotBridge  # type: ignore  # noqa: E402  # isort:skip
+
+
+class _RefusingConnector:
+    """接続拒否を模倣し、呼び出し回数を数えるテスト専用コネクタ。"""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __aenter__(self) -> "_RefusingConnector":
+        self.calls += 1
+        raise ConnectionRefusedError("refused")
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+
+class _HangingWebSocket:
+    """受信を意図的にタイムアウトさせるための擬似 WebSocket。"""
+
+    def __init__(self) -> None:
+        self.sent_messages: List[str] = []
+
+    async def __aenter__(self) -> "_HangingWebSocket":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    async def send(self, message: str) -> None:
+        self.sent_messages.append(message)
+
+    async def recv(self) -> str:
+        await asyncio.sleep(0.05)
+        return "{}"
+
+
+@pytest.mark.anyio
+async def test_connect_retry_and_logging(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    connector = _RefusingConnector()
+
+    def fake_connect(*args: Any, **kwargs: Any) -> _RefusingConnector:
+        return connector
+
+    monkeypatch.setattr(bridge_ws.websockets, "connect", fake_connect)
+
+    notifications: List[Tuple[str, int, str]] = []
+
+    async def on_retry(attempt: int, error_type: str) -> None:
+        notifications.append(("retry", attempt, error_type))
+
+    async def on_give_up(retries: int, error_type: str) -> None:
+        notifications.append(("give_up", retries, error_type))
+
+    bridge = BotBridge(
+        ws_url="ws://example",
+        max_retries=3,
+        backoff_base=0.01,
+        connect_timeout=0.01,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="bridge"):
+        result = await bridge.send({"type": "ping"}, on_retry=on_retry, on_give_up=on_give_up)
+
+    assert connector.calls == 3
+    assert result["ok"] is False
+    assert result["error"] == "connect_refused"
+    assert result["retries"] == 2
+
+    retry_events = [record for record in caplog.records if getattr(record, "event_level", "") == "retry"]
+    fault_events = [record for record in caplog.records if getattr(record, "event_level", "") == "fault"]
+    assert retry_events, "リトライイベントが記録されていません"
+    assert fault_events, "最終失敗のイベントが記録されていません"
+
+    assert notifications.count(("give_up", 2, "connect_refused")) == 1
+    recorded_retries = [item for item in notifications if item[0] == "retry"]
+    assert {item[1] for item in recorded_retries} == {1, 2}
+
+
+@pytest.mark.anyio
+async def test_receive_timeout_reports_fault(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    socket = _HangingWebSocket()
+
+    def fake_connect(*args: Any, **kwargs: Any) -> _HangingWebSocket:
+        return socket
+
+    monkeypatch.setattr(bridge_ws.websockets, "connect", fake_connect)
+
+    bridge = BotBridge(
+        ws_url="ws://example",
+        recv_timeout=0.01,
+        send_timeout=0.01,
+        connect_timeout=0.01,
+        max_retries=2,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="bridge"):
+        result = await bridge.send({"type": "status"})
+
+    assert result["ok"] is False
+    assert result["error"] == "recv_timeout"
+    fault_events = [record for record in caplog.records if getattr(record, "event_level", "") == "fault"]
+    assert fault_events, "受信タイムアウトが fault として記録されていません"
+    assert socket.sent_messages, "送信が実行されていません"


### PR DESCRIPTION
## 概要
- BotBridge.sendに接続・送信・受信のタイムアウトと接続失敗時の指数バックオフを導入し、エラー種別とリトライ回数を返すようにしました
- Actions経由で再試行/断念をチャット通知できるフックを追加し、構造化ログにevent_level=fault/retryを付与しました
- 接続拒否や受信タイムアウトをモックした単体テストを追加し、リトライ・ログ出力・通知の挙動を検証しました

## テスト
- python -m pytest tests/test_bridge_ws.py tests/test_actions_payloads.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2b1bb3d0832cb4f59895f7c7462a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-stage WS timeouts, connect-retry with backoff and error classification, exposes retry/give-up hooks and wires them through Actions, with tests for retry/timeout behavior.
> 
> - **Bridge (`python/bridge_ws.py`)**:
>   - `BotBridge.send` now applies per-stage timeouts (connect/send/recv), connect retries with exponential backoff, and returns structured failure info (`ok`, `error`, `retries`, `message`).
>   - Introduces retry/give-up hooks (`on_retry`, `on_give_up`) and structured logging (`event_level=retry|fault`).
>   - Adds error classification and backoff computation helpers.
> - **Actions (`python/actions.py`)**:
>   - Constructor accepts bridge notification hooks and `_dispatch` forwards them to `BotBridge.send`.
>   - Emits structured logs for dispatch progress/completion with success/fault levels.
> - **Tests**:
>   - New `tests/test_bridge_ws.py` verifying connect retries, give-up notifications, and recv timeout handling.
>   - Update `RecordingBridge.send` signature to accept extra kwargs; payload tests remain green.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dfd7636986d872bf9641a1714ba7959c8e30eca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->