### PR TITLE
構造化ログと計画系テストの安定化

### DIFF
--- a/python/planner.py
+++ b/python/planner.py
@@ -10,11 +10,13 @@ from pydantic import BaseModel, Field
 from utils import setup_logger
 from dotenv import load_dotenv
 import openai
-from openai import AsyncOpenAI
 from openai.types.responses import EasyInputMessageParam, Response
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from config import load_agent_config
+
+# pytest でのモンキーパッチ互換性を維持するため、従来のエイリアスを公開しておく。
+AsyncOpenAI = openai.AsyncOpenAI
 
 logger = setup_logger("planner")
 load_dotenv()
@@ -258,7 +260,7 @@ def _build_plan_graph() -> CompiledStateGraph:
             }
 
         try:
-            client = AsyncOpenAI()
+            client = openai.AsyncOpenAI()
             resp = await asyncio.wait_for(
                 client.responses.create(**state["payload"]),
                 timeout=LLM_TIMEOUT_SECONDS,
@@ -551,9 +553,7 @@ async def compose_barrier_notification(
 ) -> str:
     """作業障壁を Responses API へ説明し、プレイヤー向け確認メッセージを得る。"""
 
-    from openai import AsyncOpenAI
-
-    client = AsyncOpenAI()
+    client = openai.AsyncOpenAI()
     prompt = build_barrier_prompt(step, reason, context)
     logger.info(f"Barrier prompt: {prompt}")
 

--- a/tests/e2e/test_vpt_playback.py
+++ b/tests/e2e/test_vpt_playback.py
@@ -26,7 +26,7 @@ class DummyBridge(BotBridge):
         self.response = response
         self.requests: List[Dict[str, Any]] = []
 
-    async def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[override]
+    async def send(self, payload: Dict[str, Any], **_: Any) -> Dict[str, Any]:  # type: ignore[override]
         self.requests.append(payload)
         return self.response
 
@@ -38,7 +38,7 @@ class RecordingBridge(BotBridge):
         super().__init__(ws_url="ws://dummy")
         self.sent_payloads: List[Dict[str, Any]] = []
 
-    async def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[override]
+    async def send(self, payload: Dict[str, Any], **_: Any) -> Dict[str, Any]:  # type: ignore[override]
         self.sent_payloads.append(payload)
         return {"ok": True, "echo": payload}
 

--- a/tests/integration/test_minedojo_adapter.py
+++ b/tests/integration/test_minedojo_adapter.py
@@ -96,6 +96,9 @@ async def test_minedojo_context_is_injected_into_actions_and_memory() -> None:
             cache_dir="/tmp/minedojo-cache",
             request_timeout=5.0,
         ),
+        llm_timeout_seconds=30.0,
+        queue_max_size=10,
+        worker_task_timeout_seconds=120.0,
     )
     actions = StubActions()
     memory = Memory()


### PR DESCRIPTION
## 概要
- VPT 再生や Actions 送信スタブをリトライフック対応にし、構造化ディスパッチで型エラーが起きないようにしました
- MineDojo 構成・採掘ハンドラのテストスタブを最新の AgentConfig に追従し、オフライン時はキャッシュ済み所持品を利用して装備推論を継続できるようにしました
- Planner の AsyncOpenAI エイリアスと ReAct ログ出力をテストフレンドリーに整備し、座標付きの観測ログを残すよう改善しました

## テスト
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b300ea900832c832e83c3668efdeb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds coordinate-rich observation messages and explicit JSON ReAct logs, enables offline inventory fallback via cached memory, switches to openai.AsyncOpenAI with alias for tests, and updates VPT/test stubs for compatibility.
> 
> - **Logging/Observability**:
>   - ReAct logs now emit explicit JSON lines alongside structured logs in `python/agent.py::_emit_react_log`.
>   - Observation messages include coordinates for position detection and move success in `python/agent.py`.
> - **Execution/Orchestration**:
>   - Offline inventory fallback: when `gather_status` is unavailable, use cached `memory['inventory_detail']` to refresh summaries in `python/agent_orchestrator.py::_refresh_inventory_snapshot`.
> - **Planner/OpenAI client**:
>   - Use `openai.AsyncOpenAI()` directly; expose `AsyncOpenAI` alias for pytest compatibility in `python/planner.py` and update all client creations.
> - **Tests**:
>   - VPT bridges accept extra kwargs in `send(...)` for retry-hook compatibility in `tests/e2e/test_vpt_playback.py`.
>   - Update `AgentConfig` construction to include new fields and integrate MineDojo context assertions in `tests/integration/test_minedojo_adapter.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce1211f2366fb5ac911b055fe926c2cedbbdda2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->