### PR TITLE
液体検知時の安全停止と Bridge 応答の明示化

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Python 側の `python/actions.py` では、以下の WebSocket コマンドを�
 
 * `python/utils/logging.py` に構造化ロギングユーティリティを追加し、LangGraph ノード ID・チェックポイント ID・イベントレベルを JSON 形式で出力します。`log_structured_event` を利用すると、ノード固有の `context` メタデータを辞書で渡せます。
 * `python/agent_orchestrator.py` の建築ノードはチェックポイント更新時に `action.handle_building` というノード名でログを記録し、`event_level="recovery"` かどうかでクラッシュ復旧か通常進行かを区別します。調達計画や配置バッチもログへ含めるため、資材不足の原因調査が簡単になります。
-* `python/bridge_client.py` の HTTP 再試行も構造化ログへ統一し、最終的に失敗した場合は `event_level="fault"` を付けて LangGraph 側の再試行ノード連携に備えます。
+* `python/bridge_client.py` の HTTP 再試行も構造化ログへ統一し、最終的に失敗した場合は `event_level="fault"` を付けて LangGraph 側の再試行ノード連携に備えます。409 (液体検知) は `BridgeError` の `status_code`/`payload` に保存されるため、Mineflayer へ危険箇所を知らせて自律停止できます。
 * `python/agent.py` の ReAct ループは、各ステップの Thought/Action/Observation を `react_step` イベントとして構造化ログに記録し、Mineflayer から得られた実行結果を Observation フィールドへ即座に反映します。
 2025 年 2 月時点では `python/agent_orchestrator.py` に LangGraph ベースのステートマシンを導入し、採掘・建築・防衛の
 モジュールをノード単位で独立させました。これにより再計画時の分岐が視覚化され、`mine` → `equip` のような連鎖的な

--- a/bridge-plugin/src/main/java/com/example/bridge/jobs/MiningJob.java
+++ b/bridge-plugin/src/main/java/com/example/bridge/jobs/MiningJob.java
@@ -27,6 +27,8 @@ public final class MiningJob {
     private final String owner;
 
     private int progress; // 何ブロック前進したか
+    private boolean blockedByLiquid;
+    private BlockVector3 blockedAt;
 
     public MiningJob(
             UUID jobId,
@@ -50,6 +52,7 @@ public final class MiningJob {
         this.windowLength = Math.max(windowLength, 1);
         this.owner = owner;
         this.progress = 0;
+        this.blockedByLiquid = false;
     }
 
     public UUID jobId() {
@@ -90,6 +93,31 @@ public final class MiningJob {
 
     public boolean isFinished() {
         return progress >= length;
+    }
+
+    /**
+     * 液体検知などでジョブを一時停止する。現状は液体検知のみを対象とする。
+     */
+    public void blockForLiquid(BlockVector3 position) {
+        // 液体検知は最初の座標だけ保持し、後続の報告は無視して冪等性を保つ。
+        if (!blockedByLiquid) {
+            blockedByLiquid = true;
+            blockedAt = position;
+        }
+    }
+
+    /**
+     * ブロック状態かどうか。現時点では液体検知のみを理由とする。
+     */
+    public boolean isBlocked() {
+        return blockedByLiquid;
+    }
+
+    /**
+     * 液体で停止した座標を返す。停止していない場合は null を返す。
+     */
+    public BlockVector3 blockedPosition() {
+        return blockedAt;
     }
 
     public int windowLength() {

--- a/docs/tunnel_mode_design.md
+++ b/docs/tunnel_mode_design.md
@@ -8,6 +8,7 @@
 - `com.sun.net.httpserver.HttpServer` を用いた軽量 HTTP サーバーを起動し、`X-API-Key` 認証を必須化。
 - `/v1/jobs/*` エンドポイントで継続採掘ジョブの開始・前進・停止を提供。
 - `/v1/blocks/bulk_eval` と `/v1/coreprotect/is_player_placed_bulk` で断面評価と CoreProtect 照会をまとめて返却。
+- 液体を検知した場合は `/v1/blocks/bulk_eval` が HTTP 409 と停止座標を返し、`/v1/jobs/advance` も同様にブロック状態を明示する。
 - WorldGuard 操作はメインスレッドで行うため、`BukkitScheduler#callSyncMethod` を利用して同期実行。
 - CoreProtect API は実行時リフレクションで解決し、jar をリポジトリへ含めなくてもビルドできるように配慮。
 - `config.yml` にフロンティアの窓長や安全設定、HTTP タイムアウトを集約。
@@ -15,6 +16,7 @@
 ## Python: Bridge クライアントと Tunnel モード
 
 - `python/bridge_client.py` で HTTP クライアントを実装。指数バックオフ付きで再試行し、JSON パースを一元管理。
+- Bridge 側からの 409(液体検知) 応答を `BridgeError` の `status_code` と `payload` に格納し、Mineflayer への追加命令を止められるようにした。
 - `python/heuristics/artificial_filters.py` で自然ブロック判定と採掘マスク生成ロジックを定義。
 - `python/modes/tunnel.py` の `TunnelMode` がメインループ。AgentBridge からバルク評価を取得し、Mineflayer へ `mineBlocks` / `placeTorch` コマンドを送信。
 - `python/cli.py` に `tunnel` サブコマンドを追加し、CLI から継続採掘ジョブを起動可能にした。

--- a/node-bot/runtime/bridgeErrors.ts
+++ b/node-bot/runtime/bridgeErrors.ts
@@ -1,0 +1,18 @@
+/**
+ * AgentBridge HTTP のエラー応答から安全停止が必要かどうかを判定するヘルパー。
+ * Mineflayer が液体に遭遇した際の 409 応答を早期に検知し、
+ * 追加の採掘コマンドを送らないよう呼び出し元で分岐させることを想定している。
+ */
+export type BridgeStopPayload = {
+  error?: string;
+  stop?: boolean;
+  stop_pos?: { x: number; y: number; z: number };
+  job_id?: string;
+};
+
+export function isLiquidConflict(status: number, payload?: BridgeStopPayload | null): boolean {
+  if (status !== 409 || !payload) {
+    return false;
+  }
+  return payload.stop === true || payload.error === 'liquid_detected';
+}

--- a/node-bot/tests/bridgeErrors.test.ts
+++ b/node-bot/tests/bridgeErrors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { isLiquidConflict, type BridgeStopPayload } from '../runtime/bridgeErrors';
+
+describe('isLiquidConflict', () => {
+  it('returns true for liquid 409 payloads', () => {
+    const payload: BridgeStopPayload = { error: 'liquid_detected', stop: true };
+    expect(isLiquidConflict(409, payload)).toBe(true);
+  });
+
+  it('returns false for non-liquid 409 payloads', () => {
+    const payload: BridgeStopPayload = { error: 'other_error', stop: false };
+    expect(isLiquidConflict(409, payload)).toBe(false);
+  });
+
+  it('returns false for other status codes', () => {
+    const payload: BridgeStopPayload = { error: 'liquid_detected', stop: true };
+    expect(isLiquidConflict(200, payload)).toBe(false);
+  });
+});

--- a/tests/test_bridge_client.py
+++ b/tests/test_bridge_client.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""BridgeClient のエラーハンドリングを検証するユニットテスト。"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+import httpx
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "python"))
+
+from bridge_client import BridgeClient, BridgeError  # noqa: E402
+
+
+class BridgeClientTest(unittest.TestCase):
+    def test_bridge_error_contains_payload_and_status(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(409, json={"error": "liquid_detected", "stop": True})
+
+        transport = httpx.MockTransport(handler)
+        client = BridgeClient(base_url="http://example.com")
+        client._client = httpx.Client(transport=transport, base_url=client._base_url, headers={}, timeout=client._timeout)
+
+        with self.assertRaises(BridgeError) as ctx:
+            client.bulk_eval("world", [{"x": 0, "y": 64, "z": 0}], job_id="stub")
+
+        err = ctx.exception
+        self.assertEqual(err.status_code, 409)
+        self.assertIsInstance(err.payload, dict)
+        self.assertTrue(err.payload.get("stop"))
+
+        client.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 概要
- BridgeHttpServer の評価ロジックに液体検知の停止フラグを追加し、/v1/blocks/bulk_eval および /v1/jobs/advance で 409 を返して安全停止を明示しました。
- MiningJob に液体遭遇時のブロック状態を保持するフィールドを追加し、Bridge 側でブロック済みジョブを進めないようガードしました。
- Python BridgeClient/TunnelMode で 409 応答の詳細を BridgeError に渡し、テストとドキュメントを更新。Node 側にも液体検知用の判定ヘルパーとテストを追加しました。

## テスト
- `python -m unittest tests/test_bridge_client.py tests/test_tunnel_mode.py`
- `npm test -- --runInBand` (Node 20 では vitest が未インストール＆エンジン要件が Node 22 以上のため失敗)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bcebda6cc832c9e590b81c94b5d7a)