### PR TITLE
AgentBridgeのAPIキー必須化とHTTP認証強化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ paper-*.jar
 bridge-plugin/.gradle/
 bridge-plugin/build/
 bridge-plugin/libs/*.jar
+# Paper 実行環境で生成される AgentBridge 設定（API キーを含むため除外）
+plugins/AgentBridge/
 # AgentBridge のローカル上書き設定（LangGraph エンドポイントやシークレットを含むため除外）
 bridge-plugin/config.local.yml
 bridge-plugin/src/main/resources/config.local.yml

--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ docker compose up --build
 
 1. `bridge-plugin/libs/` に CoreProtect の jar を配置します（`.gitkeep` のみコミット済み）。
 2. Java 21 + Gradle を用意し、プラグイン直下で `./gradlew shadowJar` を実行すると `build/libs/AgentBridge-0.1.0.jar` が生成されます。
-3. Paper サーバーの `plugins/` へ配置し、初回起動後に生成される `plugins/AgentBridge/config.yml` の `api_key` を `.env` の `BRIDGE_API_KEY` と一致させます。
+3. Paper サーバーの `plugins/` へ配置し、初回起動後に生成される `plugins/AgentBridge/config.yml` の `api_key` を `.env` の `BRIDGE_API_KEY` と一致させます。`api_key` が空や `CHANGE_ME` のままの場合は HTTP サーバーを起動せず、プラグインを自動的に無効化します。
 
-HTTP サーバーは `config.yml` の `bind` / `port` で調整でき、`GET /v1/health` にアクセスすると WorldGuard/CoreProtect の有効状態を確認できます。`POST /v1/jobs/*` 系エンドポイントは必ず `X-API-Key` ヘッダーで保護してください。
+HTTP サーバーは `config.yml` の `bind` / `port` で調整でき、`GET /v1/health` にアクセスすると WorldGuard/CoreProtect の有効状態を確認できます。`POST /v1/jobs/*` 系エンドポイントは必ず `X-API-Key` ヘッダーで保護してください。認証ヘッダーがない要求はすべて拒否され、api_key が設定されていない状態ではサーバー自体が立ち上がりません。
 `langgraph.retry_endpoint` を設定すると、`POST /v1/events/disconnected` で接続断が通知された際に LangGraph リトライノードを HTTP 経由で呼び出し、Paper 側のログへノード ID とチェックポイント ID を構造化出力します。
 
 ### 3.5 継続採掘モード CLI

--- a/bridge-plugin/src/main/java/com/example/bridge/AgentBridgePlugin.java
+++ b/bridge-plugin/src/main/java/com/example/bridge/AgentBridgePlugin.java
@@ -74,10 +74,24 @@ public final class AgentBridgePlugin extends JavaPlugin {
         }
         httpServer = new BridgeHttpServer(this, bridgeConfig, jobRegistry, worldGuardFacade, coreProtectFacade, inspector,
                 retryHook, getLogger());
+        ensureApiKeyConfigured();
         try {
             httpServer.start();
         } catch (IOException e) {
             getLogger().log(Level.SEVERE, "Failed to start HTTP server", e);
         }
+    }
+
+    /**
+     * HTTP ブリッジが認証なしで外部公開されることを防ぐため、起動直前に API キーを検査する。
+     * 未設定の場合はログへ警告を残し、プラグインを無効化して明示的に初期化を中断する。
+     */
+    private void ensureApiKeyConfigured() {
+        if (bridgeConfig.hasValidApiKey()) {
+            return;
+        }
+        getLogger().warning("config.yml の api_key が未設定または CHANGE_ME のままです。AgentBridge を無効化します。");
+        getServer().getPluginManager().disablePlugin(this);
+        throw new IllegalStateException("AgentBridge HTTP server requires a non-empty api_key");
     }
 }

--- a/bridge-plugin/src/main/java/com/example/bridge/http/BridgeHttpServer.java
+++ b/bridge-plugin/src/main/java/com/example/bridge/http/BridgeHttpServer.java
@@ -331,13 +331,13 @@ public final class BridgeHttpServer {
     }
 
     private boolean authenticate(HttpExchange exchange) {
-        String expected = config.apiKey();
-        if (expected == null || expected.isEmpty()) {
-            return true;
+        if (!config.hasValidApiKey()) {
+            logger.warning(() -> "Rejecting request because api_key is not configured; check config.yml");
+            return false;
         }
         Headers headers = exchange.getRequestHeaders();
-        String provided = headers.getFirst("X-API-Key");
-        return expected.equals(provided);
+        String provided = Optional.ofNullable(headers.getFirst("X-API-Key")).map(String::trim).orElse("");
+        return !provided.isEmpty() && config.apiKey().equals(provided);
     }
 
     private void ensureMethod(HttpExchange exchange, String expected) {

--- a/bridge-plugin/src/main/resources/config.yml
+++ b/bridge-plugin/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 bind: 127.0.0.1
 port: 19071
+# 必須: Python エージェントからの呼び出しを認証するためのシークレット。空や CHANGE_ME のままだと起動を拒否します。
 api_key: "CHANGE_ME"
 timeouts:
   http_ms: 3000

--- a/bridge-plugin/src/main/resources/plugin.yml
+++ b/bridge-plugin/src/main/resources/plugin.yml
@@ -1,3 +1,4 @@
+# AgentBridge requires a non-empty api_key in config.yml; the plugin aborts startup without it.
 name: AgentBridge
 main: com.example.bridge.AgentBridgePlugin
 version: 0.1.0

--- a/docs/tunnel_mode_design.md
+++ b/docs/tunnel_mode_design.md
@@ -5,7 +5,7 @@
 ## Java: AgentBridge プラグイン
 
 - `bridge-plugin/` に Gradle プロジェクトを追加し、Paper 1.20 API を `compileOnly` で参照。
-- `com.sun.net.httpserver.HttpServer` を用いた軽量 HTTP サーバーを起動し、`X-API-Key` 認証を必須化。
+- `com.sun.net.httpserver.HttpServer` を用いた軽量 HTTP サーバーを起動し、`X-API-Key` 認証を必須化。`config.yml` の `api_key` が空・`CHANGE_ME` の場合は起動時に警告を出してプラグインを停止し、誤公開を防ぐ。
 - `/v1/jobs/*` エンドポイントで継続採掘ジョブの開始・前進・停止を提供。
 - `/v1/blocks/bulk_eval` と `/v1/coreprotect/is_player_placed_bulk` で断面評価と CoreProtect 照会をまとめて返却。
 - 液体を検知した場合は `/v1/blocks/bulk_eval` が HTTP 409 と停止座標を返し、`/v1/jobs/advance` も同様にブロック状態を明示する。


### PR DESCRIPTION
## 概要
- AgentBridgeConfigでapi_keyの空文字やCHANGE_MEを無効として扱い、起動直前に必須チェックするようにしました。
- HTTPサーバーがキー未設定の場合は警告を出してプラグインを停止し、ハンドラ側も必ずX-API-Keyヘッダーを要求するようにしました。
- plugin.ymlやconfig.yml、README/docsに必須設定である旨を明記し、生成されるプラグイン設定ディレクトリを.gitignoreへ追加しました。

## テスト
- `cd bridge-plugin && ./gradlew test` (失敗: Gradle wrapperが同梱されていないため実行不可)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bd13315e4832ca8b611318d6ebb83)