### PR TITLE
MineDojo自己対話のLangSmith連携とスキル同期機構の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ var/memory/
 var/vpt/
 python/vpt_cache/
 python/services/vpt_checkpoints/
+# LangSmith SDK が生成するローカルキャッシュやトレースダンプ（API キーやチャット内容が含まれうるため除外）
+.langsmith/
+python/.langsmith/
+langsmith.db

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ python agent.py
 - Python: 3.12.12
 - Node.js: 22.x（`.nvmrc` の指定に従う）
 - Python 依存（固定版）: `openai==1.109.1` / `python-dotenv==1.0.1` / `websockets==12.0` / `httpx==0.27.2` / `pydantic==2.8.2` / `watchfiles==0.21.0` / `langgraph==0.1.16` / `opentelemetry-api==1.27.0` / `opentelemetry-sdk==1.27.0` / `opentelemetry-exporter-otlp-proto-http==1.27.0`
+ / `langsmith==0.1.147`
 
 `pip install -r ../requirements.txt` で上記バージョンへ統一すると、`python/agent.py` の起動と Responses API 型の解決（`openai.types.responses`）がエラーなく通ることを確認済みです。
 
@@ -144,6 +145,12 @@ Python 側の `python/actions.py` では、以下の WebSocket コマンドを�
 * API 経由で MineDojo を利用する場合は `.env`（または環境変数）へ `MINEDOJO_API_KEY` を設定してください。ローカルデータセットを参照する場合は `MINEDOJO_DATASET_DIR` に JSON の配置ディレクトリ（`missions/mission_id.json`・`demos/mission_id.json`）を指定します。
 * キャッシュは `MINEDOJO_CACHE_DIR`（既定: `var/cache/minedojo`）へ保存されます。API 応答やデモ軌跡にはライセンス制限・個人データが含まれる可能性があるため、リポジトリへコミットしないでください。`.gitignore` にも除外設定を追加済みです。
 * 具体的なディレクトリ構成やデータ利用ポリシーは `docs/minedojo_integration.md` を参照してください。MineDojo 利用規約に従い、商用利用可否や二次配布の扱いをチーム内で確認してください。
+* `MINEDOJO_SIM_ENV` / `MINEDOJO_SIM_SEED` / `MINEDOJO_SIM_MAX_STEPS` で模擬環境パラメータを指定できます。`run_minedojo_self_dialogue` から自己対話フローを起動すると、これらの値とミッション/デモ情報を `MineDojoSelfDialogueExecutor` がまとめて参照し、スキル登録や学習実績の更新まで一気通貫で行います。
+
+#### LangSmith トレース
+
+* LangSmith への送信は `LANGSMITH_ENABLED` が `true` のときに有効化され、`LANGSMITH_API_URL` / `LANGSMITH_API_KEY` / `LANGSMITH_PROJECT` / `LANGSMITH_TAGS` でエンドポイントやタグを指定します。
+* `ThoughtActionObservationTracer` を `MineDojoSelfDialogueExecutor` が内部で利用し、ReAct の Thought/Action/Observation それぞれを親子 Run として送信します。CI ではダミークライアントを差し込んで外部依存なく検証するため、LangSmith が無効でもフロー全体は no-op で安全に実行されます。
 
 #### LangGraph 構造化ログとリカバリー
 

--- a/env.example
+++ b/env.example
@@ -13,6 +13,14 @@ OPENAI_REASONING_EFFORT=
 # Responses API 呼び出しのタイムアウト秒数。通信断検知と再計画を迅速化する。
 LLM_TIMEOUT_SECONDS=30
 
+# LangSmith Tracing
+LANGSMITH_ENABLED=false
+LANGSMITH_API_URL=https://api.smith.langchain.com
+LANGSMITH_PROJECT=mc-bot
+LANGSMITH_API_KEY=
+# カンマ区切りでタグを指定。空欄ならタグなし。
+LANGSMITH_TAGS=self-dialogue,minedojo
+
 # WebSocket (Python -> Node)
 WS_URL=ws://node-bot:8765
 WS_HOST=0.0.0.0
@@ -52,6 +60,15 @@ OTEL_TRACES_SAMPLER_RATIO=1.0
 # Mineflayer 側のサービス名とデプロイ環境。Collector 上のフィルタリングに活用する。
 OTEL_SERVICE_NAME=mc-node-bot
 OTEL_RESOURCE_ENVIRONMENT=development
+
+# MineDojo Simulation Defaults
+MINEDOJO_API_BASE_URL=https://api.minedojo.org/v1
+MINEDOJO_CACHE_DIR=var/cache/minedojo
+MINEDOJO_API_KEY=
+MINEDOJO_DATASET_DIR=
+MINEDOJO_SIM_ENV=creative
+MINEDOJO_SIM_SEED=42
+MINEDOJO_SIM_MAX_STEPS=120
 
 # Tunnel Mode Defaults
 TUNNEL_TORCH_INTERVAL=8

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -17,6 +17,7 @@ from .logging import (
     span_context,
     setup_logger,
 )
+from .langsmith_tracer import ThoughtActionObservationTracer
 
 __all__ = [
     "StructuredLogContext",
@@ -27,4 +28,5 @@ __all__ = [
     "log_structured_event",
     "span_context",
     "setup_logger",
+    "ThoughtActionObservationTracer",
 ]

--- a/python/utils/langsmith_tracer.py
+++ b/python/utils/langsmith_tracer.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""LangSmith SDK を用いた Thought/Action/Observation トレース送信ラッパー。"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Sequence, TYPE_CHECKING
+
+from langsmith import Client
+
+from utils import setup_logger
+
+if TYPE_CHECKING:
+    from planner import ReActStep
+else:  # pragma: no cover - テスト時の循環参照回避用
+    ReActStep = Any  # type: ignore
+
+
+class ThoughtActionObservationTracer:
+    """自己対話ステップを LangSmith へ安全に転送するための薄いラッパー。"""
+
+    def __init__(
+        self,
+        *,
+        api_url: Optional[str],
+        api_key: Optional[str],
+        project: Optional[str],
+        default_tags: Sequence[str] = (),
+        enabled: bool = True,
+        client: Optional[Client] = None,
+    ) -> None:
+        # LangSmith の接続設定を保持し、無効化フラグや API キー欠如時は完全に no-op とする。
+        self._api_url = api_url
+        self._api_key = api_key
+        self._project = project
+        self._default_tags = tuple(default_tags)
+        self._explicit_enabled = enabled
+        self._client = client
+        self._logger = setup_logger("utils.langsmith")
+
+    @property
+    def enabled(self) -> bool:
+        """トレース送信が有効かどうかを返す。"""
+
+        return bool(self._explicit_enabled and (self._client or self._api_key))
+
+    def _ensure_client(self) -> Optional[Client]:
+        """クライアントを遅延初期化し、利用可能な場合に返す。"""
+
+        if not self.enabled:
+            return None
+        if self._client:
+            return self._client
+        try:
+            self._client = Client(
+                api_key=self._api_key,
+                api_url=self._api_url,
+                default_project=self._project,
+            )
+            return self._client
+        except Exception as exc:  # pragma: no cover - SDK 初期化失敗はログのみ
+            self._logger.warning("LangSmith client initialization failed: %s", exc)
+            return None
+
+    def start_run(self, name: str, *, metadata: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        """自己対話ループ全体の親 Run を生成する。"""
+
+        client = self._ensure_client()
+        if client is None:
+            return None
+
+        run_id = str(uuid.uuid4())
+        payload: Dict[str, Any] = {
+            "id": run_id,
+            "name": name,
+            "run_type": "chain",
+            "inputs": metadata or {},
+            "tags": list(self._default_tags),
+            "start_time": datetime.now(timezone.utc),
+        }
+        try:
+            client.create_run(**payload)
+        except Exception as exc:  # pragma: no cover - 通信例外は通知のみ
+            self._logger.warning("LangSmith run creation skipped: %s", exc)
+            return None
+        return run_id
+
+    def record_step(
+        self,
+        run_id: Optional[str],
+        *,
+        step: ReActStep,
+        step_index: int,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """ReAct ステップ単位で LangSmith へ子 Run を登録する。"""
+
+        client = self._ensure_client()
+        if client is None or not run_id:
+            return
+
+        payload: Dict[str, Any] = {
+            "id": str(uuid.uuid4()),
+            "name": f"self-dialogue-step-{step_index}",
+            "run_type": "llm",
+            "inputs": {
+                "thought": step.thought,
+                "action": step.action,
+                "observation": step.observation,
+            },
+            "tags": list(self._default_tags),
+            "parent_run_id": run_id,
+            "extra": metadata or {},
+            "start_time": datetime.now(timezone.utc),
+        }
+        try:
+            client.create_run(**payload)
+        except Exception as exc:  # pragma: no cover - 通信例外は通知のみ
+            self._logger.warning("LangSmith step creation skipped: %s", exc)
+
+    def complete_run(
+        self,
+        run_id: Optional[str],
+        *,
+        outputs: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """親 Run の完了を LangSmith へ通知する。"""
+
+        client = self._ensure_client()
+        if client is None or not run_id:
+            return
+
+        payload: Dict[str, Any] = {
+            "end_time": datetime.now(timezone.utc),
+            "outputs": outputs or {},
+            "error": error,
+        }
+        try:
+            client.update_run(run_id, **payload)
+        except Exception as exc:  # pragma: no cover - 通信例外は通知のみ
+            self._logger.warning("LangSmith run completion skipped: %s", exc)
+
+
+__all__ = ["ThoughtActionObservationTracer"]

--- a/python/utils/logging.py
+++ b/python/utils/logging.py
@@ -14,7 +14,8 @@ from typing import Any, Dict, Iterator, Mapping, Optional
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 from opentelemetry.trace import Span, Status, StatusCode
 
@@ -82,10 +83,7 @@ def _configure_tracer_provider(service_name: str) -> TracerProvider:
         resource=Resource.create({"service.name": service_name}),
         sampler=ParentBased(TraceIdRatioBased(sampler_ratio)),
     )
-    exporter = OTLPSpanExporter(
-        endpoint=endpoint,
-        insecure=endpoint.startswith("http://"),
-    )
+    exporter = OTLPSpanExporter(endpoint=endpoint)
     processor = BatchSpanProcessor(exporter)
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ langgraph==0.1.16
 opentelemetry-api==1.27.0
 opentelemetry-sdk==1.27.0
 opentelemetry-exporter-otlp-proto-http==1.27.0
+langsmith==0.1.147

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -21,6 +21,14 @@ def test_load_agent_config_returns_defaults() -> None:
     assert config.minedojo.api_base_url == "https://api.minedojo.org/v1"
     assert config.minedojo.cache_dir == "var/cache/minedojo"
     assert config.minedojo.api_key is None
+    assert config.minedojo.sim_env == "creative"
+    assert config.minedojo.sim_seed == 42
+    assert config.minedojo.sim_max_steps == 120
+    assert config.langsmith.api_url == "https://api.smith.langchain.com"
+    assert config.langsmith.project == "mc-bot"
+    assert config.langsmith.api_key is None
+    assert config.langsmith.enabled is False
+    assert config.langsmith.tags == ()
     assert config.llm_timeout_seconds == 30.0
     assert config.queue_max_size == 20
     assert config.worker_task_timeout_seconds == 300.0

--- a/tests/test_langsmith_tracer.py
+++ b/tests/test_langsmith_tracer.py
@@ -1,0 +1,139 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_DIR = PROJECT_ROOT / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+from agent_orchestrator import MineDojoSelfDialogueExecutor  # type: ignore  # noqa: E402
+from planner import ReActStep  # type: ignore  # noqa: E402
+from services.minedojo_client import (  # type: ignore  # noqa: E402
+    MineDojoClient,
+    MineDojoDemonstration,
+    MineDojoMission,
+)
+from services.skill_repository import SkillRepository  # type: ignore  # noqa: E402
+from utils.langsmith_tracer import ThoughtActionObservationTracer  # type: ignore  # noqa: E402
+
+
+class StubLangSmithClient:
+    """LangSmith SDK 呼び出しを記録するシンプルなテストダブル。"""
+
+    def __init__(self) -> None:
+        self.created_runs = []
+        self.updated_runs = []
+
+    def create_run(self, **kwargs):  # type: ignore[override]
+        self.created_runs.append(kwargs)
+        return {"id": kwargs.get("id")}
+
+    def update_run(self, run_id, **kwargs):  # type: ignore[override]
+        self.updated_runs.append((run_id, kwargs))
+        return {"id": run_id}
+
+
+class StubActions:
+    """Mineflayer 連携の代わりに呼び出し内容を記録するダミー実装。"""
+
+    def __init__(self) -> None:
+        self.registered = []
+        self.invoked = []
+
+    async def register_skill(self, **kwargs):  # type: ignore[override]
+        self.registered.append(kwargs)
+        return {"ok": True, "args": kwargs}
+
+    async def invoke_skill(self, skill_id: str, *, context: str | None = None):  # type: ignore[override]
+        self.invoked.append({"skill_id": skill_id, "context": context})
+        return {"ok": True, "skill_id": skill_id, "context": context}
+
+
+class StubMineDojoClient(MineDojoClient):
+    """fetch 系のみスタブ化した MineDojo クライアント。"""
+
+    def __init__(self) -> None:
+        # Base クラスの初期化を避けるためダミー引数を与えない
+        pass
+
+    async def fetch_mission(self, mission_id: str) -> MineDojoMission | None:  # type: ignore[override]
+        return MineDojoMission(
+            mission_id=mission_id,
+            title=f"Mission {mission_id}",
+            objective="Collect wood and craft tools",
+            tags=("gather", "craft"),
+            source="stub",
+        )
+
+    async def fetch_demonstrations(
+        self, mission_id: str, *, limit: int = 1
+    ) -> list[MineDojoDemonstration]:  # type: ignore[override]
+        return [
+            MineDojoDemonstration(
+                demo_id=f"demo-{mission_id}",
+                summary="Break tree blocks and craft planks",
+                actions=(),
+                source="stub",
+            )
+            for _ in range(limit)
+        ]
+
+
+def test_thought_action_observation_tracer_records_runs() -> None:
+    client = StubLangSmithClient()
+    tracer = ThoughtActionObservationTracer(
+        api_url="http://localhost",
+        api_key="dummy",
+        project="test-project",
+        default_tags=("self-dialogue",),
+        enabled=True,
+        client=client,
+    )
+
+    run_id = tracer.start_run("demo", metadata={"mission": "abc"})
+    tracer.record_step(run_id, step=ReActStep(thought="考える", action="move", observation="ok"), step_index=0)
+    tracer.complete_run(run_id, outputs={"result": "ok"})
+
+    assert client.created_runs, "LangSmith クライアントへ create_run が送信されていません"
+    assert client.created_runs[0]["name"] == "demo"
+    assert client.updated_runs, "LangSmith クライアントへ update_run が送信されていません"
+    assert client.updated_runs[0][0] == run_id
+
+
+@pytest.mark.anyio
+async def test_self_dialogue_executor_updates_skill_and_invokes(tmp_path: Path) -> None:
+    repo_path = tmp_path / "skills.json"
+    repository = SkillRepository(str(repo_path))
+    tracer = ThoughtActionObservationTracer(
+        api_url=None,
+        api_key=None,
+        project=None,
+        enabled=False,
+    )
+    actions = StubActions()
+    client = StubMineDojoClient()
+    executor = MineDojoSelfDialogueExecutor(
+        actions=actions,
+        client=client,
+        skill_repository=repository,
+        tracer=tracer,
+        env_params={"sim_env": "creative", "sim_seed": 99, "sim_max_steps": 10},
+    )
+
+    react_trace = [ReActStep(thought="木を探す", action="move to tree", observation="見つかった")]
+    await executor.run_self_dialogue(
+        "mission-wood",
+        react_trace,
+        skill_id="skill-wood-path",
+        title="木材採集ルート",
+        success=True,
+    )
+
+    tree = await repository.get_tree()
+    node = tree.nodes.get("skill-wood-path")
+    assert node is not None
+    assert node.success_count == 1
+    assert actions.registered, "registerSkill が送信されていません"
+    assert actions.invoked, "invokeSkill が送信されていません"


### PR DESCRIPTION
## 概要
- MineDojo向けの自己対話エグゼキューターを追加し、ミッション/デモ取得・スキル登録・使用記録を一貫管理
- Thought/Action/Observation を LangSmith SDK に転送するトレーサーと環境変数・設定値を追加し、設定例を README/.env に反映
- スキル登録/更新のテストと設定読み込みテストを拡充し、LangSmith 連携のスタブで外部依存を排除

## テスト
- pytest tests/test_agent_config.py tests/test_langsmith_tracer.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c0a6f2754832c89544d110af31e92)