### PR TITLE
Phase 0: ベースライン採取ドキュメントを追加

### DIFF
--- a/docs/refactor/baseline.md
+++ b/docs/refactor/baseline.md
@@ -1,0 +1,102 @@
+# Baseline Report (Phase 0)
+
+最終更新日: 2026-04-18 (UTC)
+
+## 1. 実行コマンドと結果
+
+| コンポーネント | コマンド | 結果 | 補足 |
+|---|---|---|---|
+| Python tests | `python -m pytest tests` | ✅ 成功 | 88 passed。終了時に OTLP (`localhost:4318`) への span export リトライ警告あり。 |
+| Node tests | `bash scripts/run-node-bot.sh test` | ❌ 失敗 | 実行環境の Node が `v20.19.6` のため、スクリプト要件 (`22+`) で停止。 |
+| Node build | `bash scripts/run-node-bot.sh build` | ❌ 失敗 | 上記と同じく Node 22 未満で停止。 |
+| Bridge build | `bash scripts/build-bridge-plugin.sh` | ✅ 成功 | `shadowJar` まで成功（UP-TO-DATE 含む）。 |
+| Bridge test | `gradle test` (in `bridge-plugin/`) | ❌ 失敗 | 依存解決で `403 Forbidden`（`paperlib`, `jchronic`, `jlibnoise`）。 |
+| Compose config | `docker compose config` | ❌ 失敗 | 実行環境に `docker` コマンド無し。 |
+
+## 2. 依存と entrypoint の現状一覧
+
+### Python
+
+- 依存定義: ルート `requirements.txt`（固定バージョン pin）
+- 実行 entrypoint:
+  - `bash scripts/run-python-agent.sh`
+  - `python -m python`（`python/__main__.py`）
+- 補足:
+  - `scripts/run-python-agent.sh` は `PYTHONPATH=$repo_root:$repo_root/python` を設定して実行。
+  - `python/__main__.py` 内で `sys.path.insert(0, pythonディレクトリ)` を行っている。
+
+### Node (`node-bot/`)
+
+- 依存定義: `node-bot/package.json` + `node-bot/package-lock.json`
+- 実行 entrypoint:
+  - `bash scripts/run-node-bot.sh start|dev|build|test`
+  - `npm run dev` / `npm start`（`node-bot/package.json`）
+- 補足:
+  - スクリプト側で Node.js 22+ を強制チェック。
+
+### Bridge (`bridge-plugin/`)
+
+- 依存定義: `bridge-plugin/build.gradle.kts`
+- 実行/ビルド entrypoint:
+  - `bash scripts/build-bridge-plugin.sh`（`shadowJar`）
+  - `gradle test`（wrapper 未同梱のためシステム gradle）
+- 補足:
+  - `compileOnly(files("libs/CoreProtect-22.0.jar"))` のローカル jar 参照あり。
+
+## 3. `.env.example` / README / Compose の差異（Phase 0 観測）
+
+1. `.env` テンプレートは `env.example` 1 枚のみで、dev/prod 分離は未実施。
+2. README は `cp env.example .env` を前提としており、環境分離の導線はない。
+3. `docker-compose.yml` では起動時インストールが残っている。
+   - Node: `npm install && npm run dev`
+   - Python: `pip install -r requirements.txt && watchfiles ...`
+4. Compose 側は `.env` をそのまま参照し、dev/prod 安全デフォルトの切り替え機構は未導入。
+
+## 4. 主要実行経路ファイル（差分評価用の参照リスト）
+
+### Python planner/runtime
+
+- `python/__main__.py`
+- `python/runtime/bootstrap.py`
+- `python/runtime/unified_agent_graph.py`
+- `python/runtime/websocket_server.py`
+- `python/runtime/chat_queue.py`
+- `python/planner_config.py`
+- `requirements.txt`
+
+### Node bot runtime
+
+- `node-bot/bot.ts`
+- `node-bot/runtime/bootstrap.ts`
+- `node-bot/runtime/server.ts`
+- `node-bot/runtime/agentBridge.ts`
+- `node-bot/runtime/services/chatBridge.ts`
+- `node-bot/runtime/env.ts`
+- `node-bot/package.json`
+- `node-bot/package-lock.json`
+
+### Bridge plugin
+
+- `bridge-plugin/build.gradle.kts`
+- `bridge-plugin/src/main/java/com/example/bridge/AgentBridgePlugin.java`
+- `bridge-plugin/src/main/java/com/example/bridge/http/BridgeHttpServer.java`
+- `bridge-plugin/src/main/java/com/example/bridge/http/handlers/*.java`
+- `bridge-plugin/src/main/java/com/example/bridge/util/CoreProtectFacade.java`
+- `bridge-plugin/src/main/resources/config.yml`
+
+### 起動/運用共通
+
+- `scripts/run-python-agent.sh`
+- `scripts/run-node-bot.sh`
+- `scripts/build-bridge-plugin.sh`
+- `docker-compose.yml`
+- `docker-compose.host-services.yml`
+- `README.md`
+- `env.example`
+
+## 5. 既知問題（Phase 0 時点）
+
+- Node の baseline 実行は Node 22+ 前提のため、CI/開発環境でバージョン固定戦略が必須。
+- Bridge test は依存レポジトリへのアクセス (`403`) で不安定。
+- Compose baseline は実行環境依存（docker 未インストール）で検証不能。
+- Python 側に `PYTHONPATH` / `sys.path` 依存の import 経路が残っている（Phase 2 対象）。


### PR DESCRIPTION
### Motivation
- Phase 0 の目的に沿って、以後の段階移行で「何を壊したか」を判定できる比較基準として現状のビルド/テスト/起動のベースラインを記録する必要があった。 

### Description
- `docs/refactor/baseline.md` を新規追加し、Python / Node / Bridge / Compose 各コンポーネントの実行コマンド結果、依存と entrypoint 一覧、主要実行経路ファイルリスト、既知問題を整理して文書化した。 
- ドキュメントは Phase 0 の観測結果（Node バージョン要件、Bridge の外部依存問題、Compose 実行環境差、Python の `sys.path` 依存など）を明記して後続フェーズの参照とするよう構成した。 

### Testing
- `python -m pytest tests` を実行し `88 passed` で全テスト成功（実行終了時に OTLP (`localhost:4318`) への span export リトライ警告あり）。 
- `bash scripts/run-node-bot.sh test` と `bash scripts/run-node-bot.sh build` はローカル Node が `v20.19.6` のため失敗し、Node 22+ が必要であることを記録した。 
- `bash scripts/build-bridge-plugin.sh` は `shadowJar` まで成功したが、`gradle test` 実行では外部リポジトリからの依存取得で `403 Forbidden` が発生して失敗した。 
- `docker compose config` は実行環境に `docker` コマンドが無いため実行できずその旨を記録した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e385ffec74832ca6af62f09332a262)