### PR TITLE
Add CI, pin Python deps with constraints, use npm ci, and exclude problematic bridge transitive deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+jobs:
+  python:
+    name: Python test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -c constraints.txt
+
+      - name: Run tests
+        run: python -m pytest tests
+
+  node:
+    name: Node test/build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: node-bot
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: node-bot/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  bridge:
+    name: Bridge test/build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bridge-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '9.1.0'
+
+      - name: Run tests
+        run: gradle test --no-daemon
+
+      - name: Build shadow jar
+        run: gradle shadowJar --no-daemon

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ bash scripts/run-node-bot.sh dev
 ### 4) Python（LLM エージェント）起動
 
 ```bash
-bash scripts/setup-python-env.sh
+bash scripts/setup-python-env.sh  # requirements.txt + constraints.txt で依存を固定インストール
 bash scripts/run-python-agent.sh
 ```
 
@@ -159,7 +159,7 @@ cp env.example .env  # まだ .env が無い場合
 docker compose up --build
 ```
 
-- **Node**: `npm run dev`（`tsx`）で自動再起動
+- **Node**: `npm ci` 後に `npm run dev`（`tsx`）で自動再起動
 - **Python**: `watchfiles --filter python --ignore-paths .venv -- "python -m python"` で自動再起動
 
 Docker Desktop を使う macOS / Windows では上記のままで構いません。Linux で Compose コンテナからホスト上の Paper / OpenTelemetry Collector へ到達させたい場合は、`host-gateway` を追加する override を重ねて起動してください。

--- a/bridge-plugin/build.gradle.kts
+++ b/bridge-plugin/build.gradle.kts
@@ -22,16 +22,34 @@ repositories {
     maven("https://maven.enginehub.org/repo/")
 }
 
+
+configurations.configureEach {
+    exclude(group = "com.sk89q", module = "jchronic")
+    exclude(group = "com.sk89q.lib", module = "jlibnoise")
+}
+
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
-    compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.12")
-    compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.9")
+    compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.12") {
+        exclude(group = "io.papermc", module = "paperlib")
+    }
+    compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.9") {
+        exclude(group = "io.papermc", module = "paperlib")
+        exclude(group = "com.sk89q", module = "jchronic")
+        exclude(group = "com.sk89q.lib", module = "jlibnoise")
+    }
     implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.2")
     compileOnly(files("libs/CoreProtect-22.0.jar"))
     testImplementation("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
-    testImplementation("com.sk89q.worldguard:worldguard-bukkit:7.0.12")
-    testImplementation("com.sk89q.worldedit:worldedit-bukkit:7.3.9")
+    testImplementation("com.sk89q.worldguard:worldguard-bukkit:7.0.12") {
+        exclude(group = "io.papermc", module = "paperlib")
+    }
+    testImplementation("com.sk89q.worldedit:worldedit-bukkit:7.3.9") {
+        exclude(group = "io.papermc", module = "paperlib")
+        exclude(group = "com.sk89q", module = "jchronic")
+        exclude(group = "com.sk89q.lib", module = "jlibnoise")
+    }
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.3")
     testImplementation("org.mockito:mockito-core:5.23.0")

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,12 @@
+openai==2.30.0
+python-dotenv==1.2.2
+websockets==16.0
+httpx==0.28.1
+pydantic==2.12.5
+watchfiles==1.1.1
+langgraph==1.1.6
+opentelemetry-api==1.40.0
+opentelemetry-sdk==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.40.0
+langfuse==4.0.6
+pytest==9.0.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - -lc
       - |
         cd node-bot \
-        && npm install \
+        && npm ci \
         && npm run dev
     ports:
       - "8765:8765"
@@ -87,7 +87,7 @@ services:
         # watchfiles CLI ではコマンド全体を 1 引数として渡さないと Python が対話モードで起動してしまい、
         # エージェントがポートをリッスンしないため明示的にクォートする。プロジェクトルートのまま
         # python 配下を監視し、モジュール検索パスを /app に残して ModuleNotFound エラーを防ぐ。
-        pip install --no-cache-dir -r requirements.txt && \
+        pip install --no-cache-dir -r requirements.txt -c constraints.txt && \
         watchfiles --filter python --ignore-paths .venv -- "python -m python"
     stdin_open: true
     tty: true

--- a/docs/refactor/baseline.md
+++ b/docs/refactor/baseline.md
@@ -1,0 +1,102 @@
+# Baseline Report (Phase 0)
+
+最終更新日: 2026-04-18 (UTC)
+
+## 1. 実行コマンドと結果
+
+| コンポーネント | コマンド | 結果 | 補足 |
+|---|---|---|---|
+| Python tests | `python -m pytest tests` | ✅ 成功 | 88 passed。終了時に OTLP (`localhost:4318`) への span export リトライ警告あり。 |
+| Node tests | `bash scripts/run-node-bot.sh test` | ❌ 失敗 | 実行環境の Node が `v20.19.6` のため、スクリプト要件 (`22+`) で停止。 |
+| Node build | `bash scripts/run-node-bot.sh build` | ❌ 失敗 | 上記と同じく Node 22 未満で停止。 |
+| Bridge build | `bash scripts/build-bridge-plugin.sh` | ✅ 成功 | `shadowJar` まで成功（UP-TO-DATE 含む）。 |
+| Bridge test | `gradle test` (in `bridge-plugin/`) | ❌ 失敗 | 依存解決で `403 Forbidden`（`paperlib`, `jchronic`, `jlibnoise`）。 |
+| Compose config | `docker compose config` | ❌ 失敗 | 実行環境に `docker` コマンド無し。 |
+
+## 2. 依存と entrypoint の現状一覧
+
+### Python
+
+- 依存定義: ルート `requirements.txt`（固定バージョン pin）
+- 実行 entrypoint:
+  - `bash scripts/run-python-agent.sh`
+  - `python -m python`（`python/__main__.py`）
+- 補足:
+  - `scripts/run-python-agent.sh` は `PYTHONPATH=$repo_root:$repo_root/python` を設定して実行。
+  - `python/__main__.py` 内で `sys.path.insert(0, pythonディレクトリ)` を行っている。
+
+### Node (`node-bot/`)
+
+- 依存定義: `node-bot/package.json` + `node-bot/package-lock.json`
+- 実行 entrypoint:
+  - `bash scripts/run-node-bot.sh start|dev|build|test`
+  - `npm run dev` / `npm start`（`node-bot/package.json`）
+- 補足:
+  - スクリプト側で Node.js 22+ を強制チェック。
+
+### Bridge (`bridge-plugin/`)
+
+- 依存定義: `bridge-plugin/build.gradle.kts`
+- 実行/ビルド entrypoint:
+  - `bash scripts/build-bridge-plugin.sh`（`shadowJar`）
+  - `gradle test`（wrapper 未同梱のためシステム gradle）
+- 補足:
+  - `compileOnly(files("libs/CoreProtect-22.0.jar"))` のローカル jar 参照あり。
+
+## 3. `.env.example` / README / Compose の差異（Phase 0 観測）
+
+1. `.env` テンプレートは `env.example` 1 枚のみで、dev/prod 分離は未実施。
+2. README は `cp env.example .env` を前提としており、環境分離の導線はない。
+3. `docker-compose.yml` では起動時インストールが残っている。
+   - Node: `npm install && npm run dev`
+   - Python: `pip install -r requirements.txt && watchfiles ...`
+4. Compose 側は `.env` をそのまま参照し、dev/prod 安全デフォルトの切り替え機構は未導入。
+
+## 4. 主要実行経路ファイル（差分評価用の参照リスト）
+
+### Python planner/runtime
+
+- `python/__main__.py`
+- `python/runtime/bootstrap.py`
+- `python/runtime/unified_agent_graph.py`
+- `python/runtime/websocket_server.py`
+- `python/runtime/chat_queue.py`
+- `python/planner_config.py`
+- `requirements.txt`
+
+### Node bot runtime
+
+- `node-bot/bot.ts`
+- `node-bot/runtime/bootstrap.ts`
+- `node-bot/runtime/server.ts`
+- `node-bot/runtime/agentBridge.ts`
+- `node-bot/runtime/services/chatBridge.ts`
+- `node-bot/runtime/env.ts`
+- `node-bot/package.json`
+- `node-bot/package-lock.json`
+
+### Bridge plugin
+
+- `bridge-plugin/build.gradle.kts`
+- `bridge-plugin/src/main/java/com/example/bridge/AgentBridgePlugin.java`
+- `bridge-plugin/src/main/java/com/example/bridge/http/BridgeHttpServer.java`
+- `bridge-plugin/src/main/java/com/example/bridge/http/handlers/*.java`
+- `bridge-plugin/src/main/java/com/example/bridge/util/CoreProtectFacade.java`
+- `bridge-plugin/src/main/resources/config.yml`
+
+### 起動/運用共通
+
+- `scripts/run-python-agent.sh`
+- `scripts/run-node-bot.sh`
+- `scripts/build-bridge-plugin.sh`
+- `docker-compose.yml`
+- `docker-compose.host-services.yml`
+- `README.md`
+- `env.example`
+
+## 5. 既知問題（Phase 0 時点）
+
+- Node の baseline 実行は Node 22+ 前提のため、CI/開発環境でバージョン固定戦略が必須。
+- Bridge test は依存レポジトリへのアクセス (`403`) で不安定。
+- Compose baseline は実行環境依存（docker 未インストール）で検証不能。
+- Python 側に `PYTHONPATH` / `sys.path` 依存の import 経路が残っている（Phase 2 対象）。

--- a/docs/refactor/phase1.md
+++ b/docs/refactor/phase1.md
@@ -1,0 +1,32 @@
+## Phase 1 完了報告
+- 変更概要:
+  - GitHub Actions の CI (`.github/workflows/ci.yml`) を追加し、Python / Node / Bridge の job を分離。
+  - Node の再現性向上として Compose の `npm install` を `npm ci` へ切替。
+  - Python 依存戦略を `requirements.txt` + `constraints.txt` に明示し、セットアップスクリプトと Compose の install コマンドへ反映。
+  - Bridge の testRuntime で発生していた依存解決失敗（403）に対応するため、WorldGuard / WorldEdit 由来の未取得依存（paperlib, jchronic, jlibnoise）を除外。
+- 主な変更ファイル:
+  - `.github/workflows/ci.yml`
+  - `constraints.txt`
+  - `scripts/setup-python-env.sh`
+  - `docker-compose.yml`
+  - `bridge-plugin/build.gradle.kts`
+  - `README.md`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - ランタイム挙動変更は最小限。
+  - Compose 起動時の Node 依存解決は `npm ci` 前提になり lockfile 依存が強化される。
+  - Python の依存導入は constraints を経由するため再現性が向上。
+- 実行したコマンド:
+  - `python -m pytest tests`
+  - `bash scripts/run-node-bot.sh test`
+  - `bash scripts/run-node-bot.sh build`
+  - `cd bridge-plugin && gradle test`
+  - `docker compose config`
+- テスト結果:
+  - Python test は成功。
+  - Node test/build はローカル Node 20 のため失敗（Node 22 要件）。
+  - Bridge test は成功（transitive 依存解決失敗を回避）。
+  - `docker compose config` は docker コマンド未導入のため未実行。
+- 残課題:
+  - 本環境で Node 22 を有効化して Node 側コマンドを再確認する。
+  - CI 実行結果（GitHub Actions 実環境）で最終確認する。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,0 +1,58 @@
+{
+  "updated_at": "2026-04-18",
+  "current_phase": 1,
+  "phases": [
+    {
+      "phase": 0,
+      "name": "現状固定とベースライン採取",
+      "status": "completed",
+      "artifacts": [
+        "docs/refactor/baseline.md"
+      ]
+    },
+    {
+      "phase": 1,
+      "name": "CI / 依存再現性の確立",
+      "status": "completed",
+      "artifacts": [
+        ".github/workflows/ci.yml",
+        "constraints.txt"
+      ]
+    },
+    {
+      "phase": 2,
+      "name": "Python package 化",
+      "status": "pending"
+    },
+    {
+      "phase": 3,
+      "name": "設定分離と transport envelope 統一",
+      "status": "pending"
+    },
+    {
+      "phase": 4,
+      "name": "planner を Structured Outputs 化",
+      "status": "pending"
+    },
+    {
+      "phase": 5,
+      "name": "LangGraph persistence / interrupt 化",
+      "status": "pending"
+    },
+    {
+      "phase": 6,
+      "name": "Docker / Compose 開発フロー更新",
+      "status": "pending"
+    },
+    {
+      "phase": 7,
+      "name": "可観測性・重複整理・最終ドキュメント化",
+      "status": "pending"
+    },
+    {
+      "phase": 8,
+      "name": "研究要素の最小導入",
+      "status": "pending"
+    }
+  ]
+}

--- a/scripts/setup-python-env.sh
+++ b/scripts/setup-python-env.sh
@@ -33,7 +33,7 @@ fi
 
 "$python_bin" -m venv "$venv_dir"
 "$venv_dir/bin/python" -m pip install --upgrade pip
-"$venv_dir/bin/python" -m pip install -r "$repo_root/requirements.txt"
+"$venv_dir/bin/python" -m pip install -r "$repo_root/requirements.txt" -c "$repo_root/constraints.txt"
 
 printf 'Python environment is ready at %s\n' "$venv_dir"
 printf 'Run the agent with: bash scripts/run-python-agent.sh\n'


### PR DESCRIPTION
### Motivation

- Establish reproducible CI for Python/Node/Bridge and improve dependency/install consistency across environments.
- Fix bridge build/test failures caused by unresolved or blocked transitive dependencies and avoid non-deterministic installs in Compose and local dev.

### Description

- Add GitHub Actions workflow `.github/workflows/ci.yml` that runs Python (3.12), Node (v22) and Bridge (Java 21 + Gradle) jobs to run tests and builds.
- Add `constraints.txt` and update Python setup to install `requirements.txt` with `-c constraints.txt` by changing `scripts/setup-python-env.sh` and Compose install commands.
- Replace `npm install` with `npm ci` in `docker-compose.yml` and update README to reflect the change for deterministic Node installs.
- Update `bridge-plugin/build.gradle.kts` to exclude problematic transitive modules (`paperlib`, `jchronic`, `jlibnoise`) from WorldGuard/WorldEdit dependencies and add configuration-level excludes; add refactor docs and progress metadata under `docs/refactor/`.

### Testing

- Ran `python -m pytest tests` which succeeded (88 passed) in the baseline run.
- Running Node tests/build (`bash scripts/run-node-bot.sh test` / `npm test` / `npm run build`) failed locally due to Node v20 being below the required v22.
- Ran `gradle test` and `gradle shadowJar` in `bridge-plugin/`, and the build/tests succeeded after excluding the problematic transitive dependencies.
- Added CI workflow file to run these jobs on GitHub Actions; CI execution results should be observed on the Actions runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e385ffec74832ca6af62f09332a262)