### PR TITLE
Add CI, Python packaging & reproducible installs, and bridge dependency exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+jobs:
+  python:
+    name: Python test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -c constraints.txt
+          python -m pip install --no-deps -e .
+
+      - name: Run tests
+        run: python -m pytest tests
+
+  node:
+    name: Node test/build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: node-bot
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: node-bot/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  bridge:
+    name: Bridge test/build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bridge-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '9.1.0'
+
+      - name: Run tests
+        run: gradle test --no-daemon
+
+      - name: Build shadow jar
+        run: gradle shadowJar --no-daemon

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ bash scripts/run-node-bot.sh dev
 ### 4) Python（LLM エージェント）起動
 
 ```bash
-bash scripts/setup-python-env.sh
+bash scripts/setup-python-env.sh  # requirements.txt + constraints.txt + editable install (pyproject.toml)
 bash scripts/run-python-agent.sh
 ```
 
@@ -135,6 +135,8 @@ bash scripts/run-python-agent-watch.sh
 ```
 
 > 補足: macOS では `python` が 3.7 系を指す環境があるため、README のコマンドは `python3` 優先で動くスクリプトへ寄せています。
+
+> 補足: Python 実行パッケージは `pyproject.toml` を正本として editable install できる構成です（`bash scripts/setup-python-env.sh` で自動実行）。
 
 ### 5) Minecraft でチャットする
 
@@ -159,7 +161,7 @@ cp env.example .env  # まだ .env が無い場合
 docker compose up --build
 ```
 
-- **Node**: `npm run dev`（`tsx`）で自動再起動
+- **Node**: `npm ci` 後に `npm run dev`（`tsx`）で自動再起動
 - **Python**: `watchfiles --filter python --ignore-paths .venv -- "python -m python"` で自動再起動
 
 Docker Desktop を使う macOS / Windows では上記のままで構いません。Linux で Compose コンテナからホスト上の Paper / OpenTelemetry Collector へ到達させたい場合は、`host-gateway` を追加する override を重ねて起動してください。

--- a/bridge-plugin/build.gradle.kts
+++ b/bridge-plugin/build.gradle.kts
@@ -22,16 +22,34 @@ repositories {
     maven("https://maven.enginehub.org/repo/")
 }
 
+
+configurations.configureEach {
+    exclude(group = "com.sk89q", module = "jchronic")
+    exclude(group = "com.sk89q.lib", module = "jlibnoise")
+}
+
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
-    compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.12")
-    compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.9")
+    compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.12") {
+        exclude(group = "io.papermc", module = "paperlib")
+    }
+    compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.9") {
+        exclude(group = "io.papermc", module = "paperlib")
+        exclude(group = "com.sk89q", module = "jchronic")
+        exclude(group = "com.sk89q.lib", module = "jlibnoise")
+    }
     implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.2")
     compileOnly(files("libs/CoreProtect-22.0.jar"))
     testImplementation("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
-    testImplementation("com.sk89q.worldguard:worldguard-bukkit:7.0.12")
-    testImplementation("com.sk89q.worldedit:worldedit-bukkit:7.3.9")
+    testImplementation("com.sk89q.worldguard:worldguard-bukkit:7.0.12") {
+        exclude(group = "io.papermc", module = "paperlib")
+    }
+    testImplementation("com.sk89q.worldedit:worldedit-bukkit:7.3.9") {
+        exclude(group = "io.papermc", module = "paperlib")
+        exclude(group = "com.sk89q", module = "jchronic")
+        exclude(group = "com.sk89q.lib", module = "jlibnoise")
+    }
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.3")
     testImplementation("org.mockito:mockito-core:5.23.0")

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,12 @@
+openai==2.30.0
+python-dotenv==1.2.2
+websockets==16.0
+httpx==0.28.1
+pydantic==2.12.5
+watchfiles==1.1.1
+langgraph==1.1.6
+opentelemetry-api==1.40.0
+opentelemetry-sdk==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.40.0
+langfuse==4.0.6
+pytest==9.0.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - -lc
       - |
         cd node-bot \
-        && npm install \
+        && npm ci \
         && npm run dev
     ports:
       - "8765:8765"
@@ -79,7 +79,6 @@ services:
       AGENT_WS_PORT: ${AGENT_WS_PORT:-9000}
       BRIDGE_URL: ${COMPOSE_BRIDGE_URL:-http://bridge:19071}
       WATCHFILES_FORCE_POLLING: "true"
-      PYTHONPATH: ${PYTHONPATH:-/app:/app/python}
     command:
       - bash
       - -lc
@@ -87,7 +86,8 @@ services:
         # watchfiles CLI ではコマンド全体を 1 引数として渡さないと Python が対話モードで起動してしまい、
         # エージェントがポートをリッスンしないため明示的にクォートする。プロジェクトルートのまま
         # python 配下を監視し、モジュール検索パスを /app に残して ModuleNotFound エラーを防ぐ。
-        pip install --no-cache-dir -r requirements.txt && \
+        pip install --no-cache-dir -r requirements.txt -c constraints.txt && \
+        pip install --no-cache-dir --no-deps -e . && \
         watchfiles --filter python --ignore-paths .venv -- "python -m python"
     stdin_open: true
     tty: true

--- a/docs/refactor/baseline.md
+++ b/docs/refactor/baseline.md
@@ -1,0 +1,102 @@
+# Baseline Report (Phase 0)
+
+最終更新日: 2026-04-18 (UTC)
+
+## 1. 実行コマンドと結果
+
+| コンポーネント | コマンド | 結果 | 補足 |
+|---|---|---|---|
+| Python tests | `python -m pytest tests` | ✅ 成功 | 88 passed。終了時に OTLP (`localhost:4318`) への span export リトライ警告あり。 |
+| Node tests | `bash scripts/run-node-bot.sh test` | ❌ 失敗 | 実行環境の Node が `v20.19.6` のため、スクリプト要件 (`22+`) で停止。 |
+| Node build | `bash scripts/run-node-bot.sh build` | ❌ 失敗 | 上記と同じく Node 22 未満で停止。 |
+| Bridge build | `bash scripts/build-bridge-plugin.sh` | ✅ 成功 | `shadowJar` まで成功（UP-TO-DATE 含む）。 |
+| Bridge test | `gradle test` (in `bridge-plugin/`) | ❌ 失敗 | 依存解決で `403 Forbidden`（`paperlib`, `jchronic`, `jlibnoise`）。 |
+| Compose config | `docker compose config` | ❌ 失敗 | 実行環境に `docker` コマンド無し。 |
+
+## 2. 依存と entrypoint の現状一覧
+
+### Python
+
+- 依存定義: ルート `requirements.txt`（固定バージョン pin）
+- 実行 entrypoint:
+  - `bash scripts/run-python-agent.sh`
+  - `python -m python`（`python/__main__.py`）
+- 補足:
+  - `scripts/run-python-agent.sh` は `PYTHONPATH=$repo_root:$repo_root/python` を設定して実行。
+  - `python/__main__.py` 内で `sys.path.insert(0, pythonディレクトリ)` を行っている。
+
+### Node (`node-bot/`)
+
+- 依存定義: `node-bot/package.json` + `node-bot/package-lock.json`
+- 実行 entrypoint:
+  - `bash scripts/run-node-bot.sh start|dev|build|test`
+  - `npm run dev` / `npm start`（`node-bot/package.json`）
+- 補足:
+  - スクリプト側で Node.js 22+ を強制チェック。
+
+### Bridge (`bridge-plugin/`)
+
+- 依存定義: `bridge-plugin/build.gradle.kts`
+- 実行/ビルド entrypoint:
+  - `bash scripts/build-bridge-plugin.sh`（`shadowJar`）
+  - `gradle test`（wrapper 未同梱のためシステム gradle）
+- 補足:
+  - `compileOnly(files("libs/CoreProtect-22.0.jar"))` のローカル jar 参照あり。
+
+## 3. `.env.example` / README / Compose の差異（Phase 0 観測）
+
+1. `.env` テンプレートは `env.example` 1 枚のみで、dev/prod 分離は未実施。
+2. README は `cp env.example .env` を前提としており、環境分離の導線はない。
+3. `docker-compose.yml` では起動時インストールが残っている。
+   - Node: `npm install && npm run dev`
+   - Python: `pip install -r requirements.txt && watchfiles ...`
+4. Compose 側は `.env` をそのまま参照し、dev/prod 安全デフォルトの切り替え機構は未導入。
+
+## 4. 主要実行経路ファイル（差分評価用の参照リスト）
+
+### Python planner/runtime
+
+- `python/__main__.py`
+- `python/runtime/bootstrap.py`
+- `python/runtime/unified_agent_graph.py`
+- `python/runtime/websocket_server.py`
+- `python/runtime/chat_queue.py`
+- `python/planner_config.py`
+- `requirements.txt`
+
+### Node bot runtime
+
+- `node-bot/bot.ts`
+- `node-bot/runtime/bootstrap.ts`
+- `node-bot/runtime/server.ts`
+- `node-bot/runtime/agentBridge.ts`
+- `node-bot/runtime/services/chatBridge.ts`
+- `node-bot/runtime/env.ts`
+- `node-bot/package.json`
+- `node-bot/package-lock.json`
+
+### Bridge plugin
+
+- `bridge-plugin/build.gradle.kts`
+- `bridge-plugin/src/main/java/com/example/bridge/AgentBridgePlugin.java`
+- `bridge-plugin/src/main/java/com/example/bridge/http/BridgeHttpServer.java`
+- `bridge-plugin/src/main/java/com/example/bridge/http/handlers/*.java`
+- `bridge-plugin/src/main/java/com/example/bridge/util/CoreProtectFacade.java`
+- `bridge-plugin/src/main/resources/config.yml`
+
+### 起動/運用共通
+
+- `scripts/run-python-agent.sh`
+- `scripts/run-node-bot.sh`
+- `scripts/build-bridge-plugin.sh`
+- `docker-compose.yml`
+- `docker-compose.host-services.yml`
+- `README.md`
+- `env.example`
+
+## 5. 既知問題（Phase 0 時点）
+
+- Node の baseline 実行は Node 22+ 前提のため、CI/開発環境でバージョン固定戦略が必須。
+- Bridge test は依存レポジトリへのアクセス (`403`) で不安定。
+- Compose baseline は実行環境依存（docker 未インストール）で検証不能。
+- Python 側に `PYTHONPATH` / `sys.path` 依存の import 経路が残っている（Phase 2 対象）。

--- a/docs/refactor/phase1.md
+++ b/docs/refactor/phase1.md
@@ -1,0 +1,32 @@
+## Phase 1 完了報告
+- 変更概要:
+  - GitHub Actions の CI (`.github/workflows/ci.yml`) を追加し、Python / Node / Bridge の job を分離。
+  - Node の再現性向上として Compose の `npm install` を `npm ci` へ切替。
+  - Python 依存戦略を `requirements.txt` + `constraints.txt` に明示し、セットアップスクリプトと Compose の install コマンドへ反映。
+  - Bridge の testRuntime で発生していた依存解決失敗（403）に対応するため、WorldGuard / WorldEdit 由来の未取得依存（paperlib, jchronic, jlibnoise）を除外。
+- 主な変更ファイル:
+  - `.github/workflows/ci.yml`
+  - `constraints.txt`
+  - `scripts/setup-python-env.sh`
+  - `docker-compose.yml`
+  - `bridge-plugin/build.gradle.kts`
+  - `README.md`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - ランタイム挙動変更は最小限。
+  - Compose 起動時の Node 依存解決は `npm ci` 前提になり lockfile 依存が強化される。
+  - Python の依存導入は constraints を経由するため再現性が向上。
+- 実行したコマンド:
+  - `python -m pytest tests`
+  - `bash scripts/run-node-bot.sh test`
+  - `bash scripts/run-node-bot.sh build`
+  - `cd bridge-plugin && gradle test`
+  - `docker compose config`
+- テスト結果:
+  - Python test は成功。
+  - Node test/build はローカル Node 20 のため失敗（Node 22 要件）。
+  - Bridge test は成功（transitive 依存解決失敗を回避）。
+  - `docker compose config` は docker コマンド未導入のため未実行。
+- 残課題:
+  - 本環境で Node 22 を有効化して Node 側コマンドを再確認する。
+  - CI 実行結果（GitHub Actions 実環境）で最終確認する。

--- a/docs/refactor/phase2.md
+++ b/docs/refactor/phase2.md
@@ -1,0 +1,29 @@
+## Phase 2 進捗報告（slice 1）
+- 変更概要:
+  - `pyproject.toml` を追加し、setuptools ベースで installable project の土台を作成。
+  - Python セットアップ/CI/Compose で `pip install --no-deps -e .` を追加し、editable install 経路を導入。
+  - `python/__main__.py` から `sys.path.insert()` を削除し、公開 `main()` エントリポイントを定義。
+  - `scripts/run-python-agent*.sh` から `PYTHONPATH` 注入を除去。
+  - `tests/` 側の `sys.path.insert()` を段階的に削除（主要ケース）。
+- 主な変更ファイル:
+  - `pyproject.toml`
+  - `python/__main__.py`
+  - `scripts/setup-python-env.sh`
+  - `scripts/run-python-agent.sh`
+  - `scripts/run-python-agent-watch.sh`
+  - `.github/workflows/ci.yml`
+  - `docker-compose.yml`
+  - `tests/**/*.py`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - 起動コマンドは維持（`python -m python`）しつつ、editable install を追加した。
+  - 完全な `src/` レイアウト移行は次 slice で継続する。
+- 実行したコマンド:
+  - `python -m pytest tests`
+  - `cd bridge-plugin && gradle test`
+- テスト結果:
+  - Python test は成功。
+  - Bridge test は成功。
+- 残課題:
+  - package 名の最終整理（`src/mc_bot_agent/` への実体移動）。
+  - すべての import を package 参照へ統一。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,0 +1,63 @@
+{
+  "updated_at": "2026-04-18",
+  "current_phase": 2,
+  "phases": [
+    {
+      "phase": 0,
+      "name": "現状固定とベースライン採取",
+      "status": "completed",
+      "artifacts": [
+        "docs/refactor/baseline.md"
+      ]
+    },
+    {
+      "phase": 1,
+      "name": "CI / 依存再現性の確立",
+      "status": "completed",
+      "artifacts": [
+        ".github/workflows/ci.yml",
+        "constraints.txt"
+      ]
+    },
+    {
+      "phase": 2,
+      "name": "Python package 化",
+      "status": "in_progress",
+      "artifacts": [
+        "pyproject.toml",
+        "scripts/setup-python-env.sh",
+        ".github/workflows/ci.yml"
+      ]
+    },
+    {
+      "phase": 3,
+      "name": "設定分離と transport envelope 統一",
+      "status": "pending"
+    },
+    {
+      "phase": 4,
+      "name": "planner を Structured Outputs 化",
+      "status": "pending"
+    },
+    {
+      "phase": 5,
+      "name": "LangGraph persistence / interrupt 化",
+      "status": "pending"
+    },
+    {
+      "phase": 6,
+      "name": "Docker / Compose 開発フロー更新",
+      "status": "pending"
+    },
+    {
+      "phase": 7,
+      "name": "可観測性・重複整理・最終ドキュメント化",
+      "status": "pending"
+    },
+    {
+      "phase": 8,
+      "name": "研究要素の最小導入",
+      "status": "pending"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mc-bot-agent"
+version = "0.1.0"
+description = "Minecraft autonomous bot agent runtime"
+requires-python = ">=3.12"
+dynamic = ["dependencies"]
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+include-package-data = true
+py-modules = [
+    "agent",
+    "agent_bootstrap",
+    "agent_lifecycle",
+    "agent_orchestrator",
+    "agent_settings",
+    "bridge_client",
+    "bridge_role_handler",
+    "bridge_ws",
+    "chat_pipeline",
+    "cli",
+    "config",
+    "langgraph_state",
+    "memory",
+    "perception_service",
+    "planner_config",
+]
+
+[tool.setuptools.packages.find]
+where = ["python"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "python",
+  "tests/stubs",
+]

--- a/python/__main__.py
+++ b/python/__main__.py
@@ -4,20 +4,17 @@
 from __future__ import annotations
 
 import asyncio
-
 import os
 import sys
-from pathlib import Path
 
-from runtime.bootstrap import main
+from runtime.bootstrap import main as runtime_main
 from utils import setup_logger
 
 logger = setup_logger("agent.entrypoint")
 
-if __name__ == "__main__":
-    # runtime パッケージを確実に解決できるよう、python ディレクトリを先頭に追加する。
-    project_dir = Path(__file__).resolve().parent
-    sys.path.insert(0, str(project_dir))
+
+def main() -> None:
+    """Runtime bootstrap を起動する公開エントリポイント。"""
     logger.info(
         "starting python agent entrypoint",
         extra={
@@ -25,7 +22,6 @@ if __name__ == "__main__":
                 "cwd": os.getcwd(),
                 "sys_path": sys.path,
                 "pythonpath": os.getenv("PYTHONPATH"),
-                "sys_path_added": str(project_dir),
                 "agent_ws_host": os.getenv("AGENT_WS_HOST"),
                 "agent_ws_port": os.getenv("AGENT_WS_PORT"),
                 "agent_ws_url": os.getenv("AGENT_WS_URL"),
@@ -33,4 +29,8 @@ if __name__ == "__main__":
             }
         },
     )
-    asyncio.run(main())
+    asyncio.run(runtime_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-python-agent-watch.sh
+++ b/scripts/run-python-agent-watch.sh
@@ -10,6 +10,5 @@ if [[ ! -x "$watchfiles_bin" || ! -x "$venv_python" ]]; then
   exit 1
 fi
 
-export PYTHONPATH="$repo_root:$repo_root/python${PYTHONPATH:+:$PYTHONPATH}"
 cd "$repo_root"
 exec "$watchfiles_bin" --filter python --ignore-paths .venv -- "$venv_python -m python"

--- a/scripts/run-python-agent.sh
+++ b/scripts/run-python-agent.sh
@@ -36,6 +36,5 @@ if ! "$python_bin" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,
   exit 1
 fi
 
-export PYTHONPATH="$repo_root:$repo_root/python${PYTHONPATH:+:$PYTHONPATH}"
 cd "$repo_root"
 exec "$python_bin" -m python

--- a/scripts/setup-python-env.sh
+++ b/scripts/setup-python-env.sh
@@ -33,7 +33,8 @@ fi
 
 "$python_bin" -m venv "$venv_dir"
 "$venv_dir/bin/python" -m pip install --upgrade pip
-"$venv_dir/bin/python" -m pip install -r "$repo_root/requirements.txt"
+"$venv_dir/bin/python" -m pip install -r "$repo_root/requirements.txt" -c "$repo_root/constraints.txt"
+"$venv_dir/bin/python" -m pip install --no-deps -e "$repo_root"
 
 printf 'Python environment is ready at %s\n' "$venv_dir"
 printf 'Run the agent with: bash scripts/run-python-agent.sh\n'

--- a/tests/e2e/test_multi_agent_roles.py
+++ b/tests/e2e/test_multi_agent_roles.py
@@ -6,19 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-STUB_DIR = PROJECT_ROOT / "tests" / "stubs"
-if str(STUB_DIR) not in sys.path:
-    sys.path.insert(0, str(STUB_DIR))
-
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
 

--- a/tests/e2e/test_vpt_playback.py
+++ b/tests/e2e/test_vpt_playback.py
@@ -4,15 +4,6 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-
 from actions import Actions  # type: ignore  # noqa: E402
 from bridge_ws import BotBridge  # type: ignore  # noqa: E402
 from services import VPTController  # type: ignore  # noqa: E402

--- a/tests/integration/test_building_resume.py
+++ b/tests/integration/test_building_resume.py
@@ -3,18 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
-
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402

--- a/tests/integration/test_minedojo_adapter.py
+++ b/tests/integration/test_minedojo_adapter.py
@@ -1,16 +1,7 @@
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock
 
-import sys
-
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/integration/test_minedojo_skill_registration.py
+++ b/tests/integration/test_minedojo_skill_registration.py
@@ -1,16 +1,8 @@
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock
-
-import sys
+from pathlib import Path
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/test_action_graph_utils.py
+++ b/tests/test_action_graph_utils.py
@@ -6,11 +6,6 @@ import sys
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from runtime.action_graph_utils import with_metadata, wrap_for_logging
 
 

--- a/tests/test_actions_payloads.py
+++ b/tests/test_actions_payloads.py
@@ -7,11 +7,6 @@ from typing import Any, Dict, List, Sequence
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from actions import ActionValidationError, Actions  # type: ignore  # noqa: E402
 
 

--- a/tests/test_agent_bootstrap.py
+++ b/tests/test_agent_bootstrap.py
@@ -8,11 +8,6 @@ import sys
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from agent_settings import AgentRuntimeSettings  # type: ignore  # noqa: E402
 from config import AgentConfig, DashboardConfig, LangfuseConfig, MineDojoConfig  # type: ignore  # noqa: E402

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -2,11 +2,6 @@ from pathlib import Path
 
 import sys
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from config import load_agent_config  # type: ignore  # noqa: E402
 
 

--- a/tests/test_agent_equip.py
+++ b/tests/test_agent_equip.py
@@ -13,11 +13,6 @@ import pytest
 import sys
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402

--- a/tests/test_agent_mine.py
+++ b/tests/test_agent_mine.py
@@ -11,11 +11,6 @@ import pytest
 import sys
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402

--- a/tests/test_agent_perception.py
+++ b/tests/test_agent_perception.py
@@ -6,11 +6,6 @@ from pathlib import Path
 
 import sys
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
 

--- a/tests/test_agent_replan.py
+++ b/tests/test_agent_replan.py
@@ -10,11 +10,6 @@ import pytest
 import sys
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402

--- a/tests/test_agent_task_classification.py
+++ b/tests/test_agent_task_classification.py
@@ -11,11 +11,6 @@ import pytest
 import sys
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402

--- a/tests/test_bridge_ws.py
+++ b/tests/test_bridge_ws.py
@@ -8,11 +8,6 @@ from typing import Any, List, Tuple
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 import bridge_ws  # noqa: E402  # isort:skip
 from bridge_ws import BotBridge  # type: ignore  # noqa: E402  # isort:skip
 

--- a/tests/test_building_plan_processor.py
+++ b/tests/test_building_plan_processor.py
@@ -7,11 +7,6 @@ from typing import Any, Dict
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from runtime.building_plan_processor import BuildingPlanProcessor
 
 

--- a/tests/test_langfuse_tracer.py
+++ b/tests/test_langfuse_tracer.py
@@ -3,11 +3,6 @@ import sys
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from runtime.minedojo import MineDojoSelfDialogueExecutor  # type: ignore  # noqa: E402
 from planner import ReActStep  # type: ignore  # noqa: E402
 from services.minedojo_client import (  # type: ignore  # noqa: E402

--- a/tests/test_langgraph_scenarios.py
+++ b/tests/test_langgraph_scenarios.py
@@ -15,11 +15,6 @@ import sys
 pytest.importorskip("langgraph")
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
 from planner import (  # type: ignore  # noqa: E402

--- a/tests/test_move_handler.py
+++ b/tests/test_move_handler.py
@@ -7,11 +7,6 @@ from typing import Any, Dict, Optional, Tuple
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from services.movement_service import MovementResult
 from runtime.move_handler import handle_move
 

--- a/tests/test_reflexion_memory.py
+++ b/tests/test_reflexion_memory.py
@@ -6,11 +6,6 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from memory import Memory  # type: ignore  # noqa: E402
 from services.reflection_store import ReflectionStore  # type: ignore  # noqa: E402
 

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -5,19 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from pathlib import Path
-import sys
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-STUB_DIR = PROJECT_ROOT / "tests" / "stubs"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-if str(STUB_DIR) not in sys.path:
-    sys.path.insert(0, str(STUB_DIR))
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from bridge_client import BRIDGE_RETRY, BridgeClient, BridgeError  # type: ignore  # noqa: E402

--- a/tests/test_task_router.py
+++ b/tests/test_task_router.py
@@ -11,11 +11,6 @@ import pytest
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from orchestrator.action_analyzer import ActionAnalyzer  # type: ignore  # noqa: E402
 from orchestrator.task_router import TaskRouter  # type: ignore  # noqa: E402
 


### PR DESCRIPTION
### Motivation

- Improve developer and CI reproducibility by adding a GitHub Actions CI that runs Python, Node, and Bridge jobs and by pinning/controlling Python dependency resolution. 
- Convert the Python runtime into an installable editable package to remove ad-hoc `PYTHONPATH` manipulations and make test imports reliable. 
- Fix Bridge build/test failures caused by transitive/blocked dependencies by excluding problematic transitive artifacts from WorldEdit/WorldGuard coordinates.

### Description

- Added GitHub Actions workflow `.github/workflows/ci.yml` with separate `python`, `node`, and `bridge` jobs that run `python -m pytest tests`, `npm test`/`npm run build`, and `gradle test`/`shadowJar` respectively. 
- Introduced `constraints.txt` and updated installation flows to use constraint files for reproducible Python installs, and added `pyproject.toml` plus editable install support (`pip install --no-deps -e .`).
- Refactored Python entrypoints and scripts: made `python/__main__.py` expose a `main()` that calls the runtime bootstrap (`runtime.bootstrap.main` renamed import), removed runtime `sys.path` injection, and removed `PYTHONPATH` exports from `scripts/run-python-agent.sh` and `scripts/run-python-agent-watch.sh`; updated `scripts/setup-python-env.sh` to install with constraints and perform editable install. 
- Updated `docker-compose.yml` to replace `npm install` with `npm ci` and to install Python deps using `-c constraints.txt` and editable install during the python-agent service startup. 
- Modified `bridge-plugin/build.gradle.kts` to exclude transitive/undeployable modules (`paperlib`, `jchronic`, `jlibnoise`) from WorldEdit/WorldGuard dependencies to avoid 403/resolution issues. 
- Cleaned up many tests to remove manual `sys.path`/PYTHONPATH hacks and rely on the package layout (removed repeated `sys.path.insert` stubs across tests). 
- Added refactor documentation and progress artifacts under `docs/refactor/` (`baseline.md`, `phase1.md`, `phase2.md`, and `progress.json`).

### Testing

- Ran Python unit tests with `python -m pytest tests`, which passed (`88 passed`).
- Built and tested the Bridge plugin with `cd bridge-plugin && gradle test` and `gradle shadowJar`, which succeeded after excluding problematic transitive dependencies. 
- Local Node test/build (`bash scripts/run-node-bot.sh test` / `build`) failed in the local environment due to Node version (`v20` vs required `22+`), but the CI workflow includes a Node job using Node `22` to run `npm test` and `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e385ffec74832ca6af62f09332a262)