### PR TITLE
python: Phase 2 - Python を installable package 前提へ移行（pyproject + entrypoint）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -c constraints.txt
+          python -m pip install -e .
 
       - name: Run tests
         run: python -m pytest tests

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ bash scripts/run-node-bot.sh dev
 ### 4) Python（LLM エージェント）起動
 
 ```bash
-bash scripts/setup-python-env.sh  # requirements.txt + constraints.txt で依存を固定インストール
+bash scripts/setup-python-env.sh  # requirements.txt + constraints.txt + editable install で依存を固定
 bash scripts/run-python-agent.sh
 ```
 
@@ -160,7 +160,7 @@ docker compose up --build
 ```
 
 - **Node**: `npm ci` 後に `npm run dev`（`tsx`）で自動再起動
-- **Python**: `watchfiles --filter python --ignore-paths .venv -- "python -m python"` で自動再起動
+- **Python**: `watchfiles --filter python --ignore-paths .venv -- "python -m mc_bot_agent_entrypoint"` で自動再起動
 
 Docker Desktop を使う macOS / Windows では上記のままで構いません。Linux で Compose コンテナからホスト上の Paper / OpenTelemetry Collector へ到達させたい場合は、`host-gateway` を追加する override を重ねて起動してください。
 

--- a/docs/refactor/phase2.md
+++ b/docs/refactor/phase2.md
@@ -1,0 +1,31 @@
+## Phase 2 完了報告
+- 変更概要:
+  - `pyproject.toml` を追加し、Python 実装を editable install 可能な installable package 構成へ移行。
+  - 既存の `sys.path`/`PYTHONPATH` 前提を削減するため、`mc_bot_agent_entrypoint` を導入し、起動スクリプトと CI の Python install フローを更新。
+  - `tests/` 配下の `sys.path` 挿入を除去し、パッケージインストール後の import 経路を正本化。
+  - README の Python セットアップ/ホットリロード実行例を新しい起動モジュールに同期。
+- 主な変更ファイル:
+  - `pyproject.toml`
+  - `python/mc_bot_agent_entrypoint.py`
+  - `python/__main__.py`
+  - `scripts/setup-python-env.sh`
+  - `scripts/run-python-agent.sh`
+  - `scripts/run-python-agent-watch.sh`
+  - `.github/workflows/ci.yml`
+  - `tests/*.py`, `tests/integration/*.py`, `tests/e2e/*.py`
+  - `README.md`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - Python 実行は editable install (`pip install -e .`) 前提となる。
+  - `python -m python` 実行は内部的に `mc_bot_agent_entrypoint` へフォワードされ、既存利用者の挙動を維持。
+  - テストは `sys.path` 直接操作ではなく、インストール済みモジュール解決に依存する。
+- 実行したコマンド:
+  - `python -m pip install -e .`
+  - `python -m pytest tests/test_langgraph_scenarios.py`
+  - `python -m pytest tests`
+- テスト結果:
+  - すべて成功（88 passed）。
+  - OpenTelemetry span export はローカル collector 不在で警告が出るが、pytest 終了コードは成功。
+- 残課題:
+  - `src/` レイアウトへの再配置は未着手（既存 import 経路の後方互換を維持するため段階移行とする）。
+  - Compose の Python サービスで残る `PYTHONPATH`/起動時 install の整理は Phase 6 で実施する。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,6 +1,6 @@
 {
   "updated_at": "2026-04-18",
-  "current_phase": 1,
+  "current_phase": 2,
   "phases": [
     {
       "phase": 0,
@@ -22,7 +22,12 @@
     {
       "phase": 2,
       "name": "Python package 化",
-      "status": "pending"
+      "status": "completed",
+      "artifacts": [
+        "pyproject.toml",
+        "python/mc_bot_agent_entrypoint.py",
+        "docs/refactor/phase2.md"
+      ]
     },
     {
       "phase": 3,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mc-bot-agent"
+version = "0.1.0"
+description = "Minecraft bot orchestrator components"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[project.scripts]
+mc-bot-agent = "mc_bot_agent_entrypoint:run"
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+py-modules = [
+  "agent",
+  "agent_bootstrap",
+  "agent_lifecycle",
+  "agent_orchestrator",
+  "agent_settings",
+  "bridge_client",
+  "bridge_role_handler",
+  "bridge_ws",
+  "chat_pipeline",
+  "cli",
+  "config",
+  "langgraph_state",
+  "mc_bot_agent_entrypoint",
+  "memory",
+  "perception_service",
+  "planner_config",
+]
+
+[tool.setuptools.packages.find]
+where = ["python"]
+include = [
+  "actions",
+  "dashboard",
+  "llm",
+  "modes",
+  "orchestrator",
+  "planner",
+  "runtime",
+  "services",
+  "skills",
+  "utils",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/python/__main__.py
+++ b/python/__main__.py
@@ -1,36 +1,7 @@
 # -*- coding: utf-8 -*-
 """Python エージェント実行用のエントリポイント。"""
 
-from __future__ import annotations
-
-import asyncio
-
-import os
-import sys
-from pathlib import Path
-
-from runtime.bootstrap import main
-from utils import setup_logger
-
-logger = setup_logger("agent.entrypoint")
+from mc_bot_agent_entrypoint import run
 
 if __name__ == "__main__":
-    # runtime パッケージを確実に解決できるよう、python ディレクトリを先頭に追加する。
-    project_dir = Path(__file__).resolve().parent
-    sys.path.insert(0, str(project_dir))
-    logger.info(
-        "starting python agent entrypoint",
-        extra={
-            "structured_context": {
-                "cwd": os.getcwd(),
-                "sys_path": sys.path,
-                "pythonpath": os.getenv("PYTHONPATH"),
-                "sys_path_added": str(project_dir),
-                "agent_ws_host": os.getenv("AGENT_WS_HOST"),
-                "agent_ws_port": os.getenv("AGENT_WS_PORT"),
-                "agent_ws_url": os.getenv("AGENT_WS_URL"),
-                "ws_url": os.getenv("WS_URL"),
-            }
-        },
-    )
-    asyncio.run(main())
+    run()

--- a/python/mc_bot_agent_entrypoint.py
+++ b/python/mc_bot_agent_entrypoint.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Installable Python agent entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from runtime.bootstrap import main
+from utils import setup_logger
+
+logger = setup_logger("agent.entrypoint")
+
+
+def run() -> None:
+    logger.info(
+        "starting python agent entrypoint",
+        extra={
+            "structured_context": {
+                "cwd": os.getcwd(),
+                "agent_ws_host": os.getenv("AGENT_WS_HOST"),
+                "agent_ws_port": os.getenv("AGENT_WS_PORT"),
+                "agent_ws_url": os.getenv("AGENT_WS_URL"),
+                "ws_url": os.getenv("WS_URL"),
+            }
+        },
+    )
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/run-python-agent-watch.sh
+++ b/scripts/run-python-agent-watch.sh
@@ -10,6 +10,5 @@ if [[ ! -x "$watchfiles_bin" || ! -x "$venv_python" ]]; then
   exit 1
 fi
 
-export PYTHONPATH="$repo_root:$repo_root/python${PYTHONPATH:+:$PYTHONPATH}"
 cd "$repo_root"
-exec "$watchfiles_bin" --filter python --ignore-paths .venv -- "$venv_python -m python"
+exec "$watchfiles_bin" --filter python --ignore-paths .venv -- "$venv_python -m mc_bot_agent_entrypoint"

--- a/scripts/run-python-agent.sh
+++ b/scripts/run-python-agent.sh
@@ -36,6 +36,5 @@ if ! "$python_bin" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,
   exit 1
 fi
 
-export PYTHONPATH="$repo_root:$repo_root/python${PYTHONPATH:+:$PYTHONPATH}"
 cd "$repo_root"
-exec "$python_bin" -m python
+exec "$python_bin" -m mc_bot_agent_entrypoint

--- a/scripts/setup-python-env.sh
+++ b/scripts/setup-python-env.sh
@@ -34,6 +34,7 @@ fi
 "$python_bin" -m venv "$venv_dir"
 "$venv_dir/bin/python" -m pip install --upgrade pip
 "$venv_dir/bin/python" -m pip install -r "$repo_root/requirements.txt" -c "$repo_root/constraints.txt"
+"$venv_dir/bin/python" -m pip install -e "$repo_root"
 
 printf 'Python environment is ready at %s\n' "$venv_dir"
 printf 'Run the agent with: bash scripts/run-python-agent.sh\n'

--- a/tests/e2e/test_multi_agent_roles.py
+++ b/tests/e2e/test_multi_agent_roles.py
@@ -1,27 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-STUB_DIR = PROJECT_ROOT / "tests" / "stubs"
-if str(STUB_DIR) not in sys.path:
-    sys.path.insert(0, str(STUB_DIR))
-
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
-
 
 ROLE_LABELS = {
     "generalist": "汎用サポーター",
@@ -29,7 +15,6 @@ ROLE_LABELS = {
     "supplier": "補給調整",
     "scout": "先行偵察",
 }
-
 
 class RecordingActions:
     """テスト用にアクション呼び出しを記録する簡易スタブ。"""
@@ -68,7 +53,6 @@ class RecordingActions:
         label = ROLE_LABELS.get(role_id, role_id)
         return {"ok": True, "data": {"roleId": role_id, "label": label}}
 
-
 def test_defender_role_selected_when_threat_detected() -> None:
     async def runner() -> None:
         actions = RecordingActions()
@@ -104,7 +88,6 @@ def test_defender_role_selected_when_threat_detected() -> None:
         assert active_role.get("id") == "defender"
 
     asyncio.run(runner())
-
 
 def test_supplier_role_coordinates_replenishment_meetup() -> None:
     async def runner() -> None:

--- a/tests/e2e/test_vpt_playback.py
+++ b/tests/e2e/test_vpt_playback.py
@@ -1,22 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
-
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 from actions import Actions  # type: ignore  # noqa: E402
 from bridge_ws import BotBridge  # type: ignore  # noqa: E402
 from services import VPTController  # type: ignore  # noqa: E402
-
 
 class DummyBridge(BotBridge):
     """テスト用に WebSocket を実際には開かずに応答を差し込むスタブ。"""
@@ -30,7 +19,6 @@ class DummyBridge(BotBridge):
         self.requests.append(payload)
         return self.response
 
-
 class RecordingBridge(BotBridge):
     """送信内容だけを記録する簡易スタブ。"""
 
@@ -41,7 +29,6 @@ class RecordingBridge(BotBridge):
     async def send(self, payload: Dict[str, Any], **_: Any) -> Dict[str, Any]:  # type: ignore[override]
         self.sent_payloads.append(payload)
         return {"ok": True, "echo": payload}
-
 
 def build_sample_observation() -> Mapping[str, Any]:
     return {
@@ -54,7 +41,6 @@ def build_sample_observation() -> Mapping[str, Any]:
         "hotbar": [{"count": 4}, {"count": 1}],
     }
 
-
 def test_vpt_controller_generates_alignment_actions() -> None:
     controller = VPTController(tick_interval_ms=50.0)
     observation = build_sample_observation()
@@ -65,7 +51,6 @@ def test_vpt_controller_generates_alignment_actions() -> None:
     assert actions[0]["relative"] is True
     assert actions[1]["kind"] == "control"
     assert actions[1]["control"] == "forward"
-
 
 def test_gather_observation_via_bridge() -> None:
     async def runner() -> None:
@@ -79,7 +64,6 @@ def test_gather_observation_via_bridge() -> None:
         assert bridge.requests[0]["type"] == "gatherVptObservation"
 
     asyncio.run(runner())
-
 
 def test_actions_dispatches_vpt_sequence() -> None:
     async def runner() -> None:

--- a/tests/integration/test_building_resume.py
+++ b/tests/integration/test_building_resume.py
@@ -3,18 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
-
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
@@ -25,7 +16,6 @@ from services import (  # type: ignore  # noqa: E402
     restore_checkpoint,
     rollback_building_state,
 )
-
 
 class PassiveActions:
     """Mineflayer 呼び出しをスタブ化したアクション群。"""
@@ -59,13 +49,11 @@ class PassiveActions:
     ) -> Dict[str, Any]:
         return {"ok": True, "ores": list(ore_names)}
 
-
 @pytest.fixture
 def building_orchestrator() -> AgentOrchestrator:
     actions = PassiveActions()
     memory = Memory()
     return AgentOrchestrator(actions, memory)
-
 
 def _run_build_node(
     orchestrator: AgentOrchestrator,
@@ -80,7 +68,6 @@ def _run_build_node(
         )
 
     return asyncio.run(runner())
-
 
 def test_checkpoint_restoration_and_procurement_plan(building_orchestrator: AgentOrchestrator) -> None:
     orchestrator = building_orchestrator
@@ -119,7 +106,6 @@ def test_checkpoint_restoration_and_procurement_plan(building_orchestrator: Agen
     assert "placement" in backlog[0]
     assert "glass:4" in backlog[0]["procurement"]
 
-
 def test_phase_transition_to_placement_and_inspection(building_orchestrator: AgentOrchestrator) -> None:
     orchestrator = building_orchestrator
     requirements = {"oak_planks": 3}
@@ -150,7 +136,6 @@ def test_phase_transition_to_placement_and_inspection(building_orchestrator: Age
     assert failure_second is None
     assert backlog_second[0]["phase"] == BuildingPhase.INSPECTION.value
     assert backlog_second[0]["placement"] == "なし"
-
 
 def test_rollback_restores_previous_phase(building_orchestrator: AgentOrchestrator) -> None:
     orchestrator = building_orchestrator

--- a/tests/integration/test_minedojo_adapter.py
+++ b/tests/integration/test_minedojo_adapter.py
@@ -1,24 +1,13 @@
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock
 
-import sys
-
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-
 pytestmark = pytest.mark.anyio
-
 
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
-
 
 async def test_minedojo_context_is_injected_into_actions_and_memory() -> None:
     pytest.importorskip("langgraph")

--- a/tests/integration/test_minedojo_skill_registration.py
+++ b/tests/integration/test_minedojo_skill_registration.py
@@ -2,23 +2,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock
 
-import sys
-
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-
 pytestmark = pytest.mark.anyio
-
 
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
-
 
 async def test_minedojo_demo_registration_and_reuse(tmp_path: Path) -> None:
     pytest.importorskip("langgraph")

--- a/tests/stubs/bridge_stub.py
+++ b/tests/stubs/bridge_stub.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List
 
-
 class BridgeStub:
     """TunnelMode の統合テストで利用する単純なスタブ実装。"""
 
@@ -56,6 +55,5 @@ class BridgeStub:
     def stop(self, job_id: str):
         self.stopped = True
         return {"ok": True}
-
 
 __all__ = ["BridgeStub"]

--- a/tests/stubs/langgraph/graph/__init__.py
+++ b/tests/stubs/langgraph/graph/__init__.py
@@ -13,7 +13,6 @@ END = "__end__"
 NodeCallable = Callable[[MutableMapping[str, Any]], Awaitable[Dict[str, Any]] | Dict[str, Any]]
 ResolverCallable = Callable[[MutableMapping[str, Any]], Any]
 
-
 class StateGraph:
     """LangGraph StateGraph の単純なスタブ実装。"""
 
@@ -39,6 +38,5 @@ class StateGraph:
 
     def compile(self) -> CompiledStateGraph:
         return CompiledStateGraph(self._nodes, self._edges, self._conditional)
-
 
 __all__ = ["START", "END", "StateGraph"]

--- a/tests/stubs/langgraph/graph/state.py
+++ b/tests/stubs/langgraph/graph/state.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Awaitable, Dict, Mapping, MutableMapping, Callable
 
-
 NodeCallable = Callable[[MutableMapping[str, Any]], Awaitable[Dict[str, Any]] | Dict[str, Any]]
 ResolverCallable = Callable[[MutableMapping[str, Any]], Any]
-
 
 class CompiledStateGraph:
     """StateGraph.compile() が返す簡易スタブ。"""
@@ -53,6 +51,5 @@ class CompiledStateGraph:
             current = node_name
 
         return state
-
 
 __all__ = ["CompiledStateGraph"]

--- a/tests/test_action_graph_utils.py
+++ b/tests/test_action_graph_utils.py
@@ -1,18 +1,10 @@
 # -*- coding: utf-8 -*-
 """ActionGraph ユーティリティの単体テスト。"""
 import asyncio
-from pathlib import Path
-import sys
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from runtime.action_graph_utils import with_metadata, wrap_for_logging
-
 
 def test_with_metadata_merges_base_and_records_event():
     state = {"structured_events": []}
@@ -30,7 +22,6 @@ def test_with_metadata_merges_base_and_records_event():
     assert result["inputs"] == {"foo": "bar"}
     assert result["outputs"]["handled"] is True
 
-
 def test_wrap_for_logging_appends_structured_event():
     async def sample_node(state):
         return {"handled": True, "module": "move"}
@@ -42,7 +33,6 @@ def test_wrap_for_logging_appends_structured_event():
 
     assert result["handled"] is True
     assert any(event.get("step_label") == "sample" for event in result["structured_events"])
-
 
 def test_wrap_for_logging_skips_duplicate_entries():
     async def sample_node(state):

--- a/tests/test_actions_payloads.py
+++ b/tests/test_actions_payloads.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
 import logging
-import sys
-from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from actions import ActionValidationError, Actions  # type: ignore  # noqa: E402
-
 
 class RecordingBridge:
     """テスト用に送信内容を記録する簡易 WebSocket ブリッジ。"""
@@ -25,7 +17,6 @@ class RecordingBridge:
     async def send(self, payload: Dict[str, Any], **_: Any) -> Dict[str, Any]:  # noqa: D401 - テスト用スタブ
         self.sent.append(payload)
         return self.response | {"echo": payload}
-
 
 class ScriptedBridge(RecordingBridge):
     """送信ごとに異なるレスポンスを返すブリッジ。"""
@@ -42,7 +33,6 @@ class ScriptedBridge(RecordingBridge):
             response = {"ok": True}
         return response | {"echo": payload}
 
-
 @pytest.mark.anyio
 async def test_mine_blocks_payload() -> None:
     bridge = RecordingBridge()
@@ -55,7 +45,6 @@ async def test_mine_blocks_payload() -> None:
         "args": {"positions": [{"x": 1, "y": 64, "z": -3}]},
     }
     assert result["ok"] is True
-
 
 @pytest.mark.anyio
 async def test_place_block_payload_with_face() -> None:
@@ -74,7 +63,6 @@ async def test_place_block_payload_with_face() -> None:
         },
     }
 
-
 @pytest.mark.anyio
 async def test_follow_player_payload() -> None:
     bridge = RecordingBridge()
@@ -87,7 +75,6 @@ async def test_follow_player_payload() -> None:
         "args": {"target": "Taishi", "stopDistance": 4, "maintainLineOfSight": False},
     }
 
-
 @pytest.mark.anyio
 async def test_attack_entity_mode_validation() -> None:
     bridge = RecordingBridge()
@@ -95,7 +82,6 @@ async def test_attack_entity_mode_validation() -> None:
 
     with pytest.raises(ActionValidationError):
         await actions.attack_entity("zombie", mode="invalid")
-
 
 @pytest.mark.anyio
 async def test_craft_item_payload() -> None:
@@ -108,7 +94,6 @@ async def test_craft_item_payload() -> None:
         "type": "craftItem",
         "args": {"item": "oak_planks", "amount": 3, "useCraftingTable": False},
     }
-
 
 @pytest.mark.anyio
 async def test_dispatch_outputs_structured_log(caplog: pytest.LogCaptureFixture) -> None:
@@ -124,7 +109,6 @@ async def test_dispatch_outputs_structured_log(caplog: pytest.LogCaptureFixture)
     assert progress, "dispatch prepared ログが出力されていません"
     assert completed, "dispatch completed ログが出力されていません"
 
-
 @pytest.mark.anyio
 async def test_validate_positions_rejects_empty() -> None:
     bridge = RecordingBridge()
@@ -132,7 +116,6 @@ async def test_validate_positions_rejects_empty() -> None:
 
     with pytest.raises(ActionValidationError):
         await actions.mine_blocks([])
-
 
 @pytest.mark.anyio
 async def test_execute_hybrid_action_uses_vpt_when_available() -> None:
@@ -147,7 +130,6 @@ async def test_execute_hybrid_action_uses_vpt_when_available() -> None:
 
     assert result["executor"] == "vpt"
     assert bridge.sent[-1]["type"] == "playVptActions"
-
 
 @pytest.mark.anyio
 async def test_execute_hybrid_action_falls_back_to_command() -> None:
@@ -167,7 +149,6 @@ async def test_execute_hybrid_action_falls_back_to_command() -> None:
     assert result["executor"] == "command"
     assert len(bridge.sent) == 2
     assert bridge.sent[-1]["type"] == "moveTo"
-
 
 @pytest.mark.anyio
 async def test_execute_hybrid_action_requires_payloads() -> None:

--- a/tests/test_agent_bootstrap.py
+++ b/tests/test_agent_bootstrap.py
@@ -1,24 +1,17 @@
 """initialize_agent_runtime の注入ロジックに関するテスト。"""
 
 from __future__ import annotations
+from pathlib import Path
 
 from dataclasses import dataclass
-from pathlib import Path
-import sys
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from agent_settings import AgentRuntimeSettings  # type: ignore  # noqa: E402
 from config import AgentConfig, DashboardConfig, LangfuseConfig, MineDojoConfig  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
 from runtime.inventory_sync import InventorySynchronizer  # type: ignore  # noqa: E402
-
 
 @dataclass
 class StubActions:
@@ -39,7 +32,6 @@ class StubActions:
         # status_service 側の呼び出しをモックしやすくするため、固定レスポンスを返す。
         return {"ok": True, "data": {"kind": kind}}
 
-
 class SkillRepositoryStub:
     """永続化を伴わないテスト用のスキルリポジトリスタブ。"""
 
@@ -49,13 +41,11 @@ class SkillRepositoryStub:
     async def record_usage(self, skill_id: str, *, success: bool) -> None:  # pragma: no cover - 呼び出しはテスト外
         self.recorded.append(skill_id)
 
-
 class MineDojoClientStub:
     """MineDojoClient の差し替え用にフィールドのみを持つ簡易スタブ。"""
 
     def __init__(self) -> None:
         self.used = False
-
 
 @pytest.fixture
 def base_config(tmp_path: Path) -> AgentConfig:
@@ -98,7 +88,6 @@ def base_config(tmp_path: Path) -> AgentConfig:
         ),
     )
 
-
 def test_initialize_agent_runtime_applies_custom_settings(base_config: AgentConfig) -> None:
     """カスタム設定が PlanRuntimeContext と依存セットに伝搬することを確認する。"""
 
@@ -131,7 +120,6 @@ def test_initialize_agent_runtime_applies_custom_settings(base_config: AgentConf
     assert orchestrator._plan_runtime.structured_event_history_limit == 42
     assert orchestrator._plan_runtime.perception_history_limit == 24
     assert orchestrator._dependencies.runtime_settings is runtime_settings
-
 
 def test_initialize_agent_runtime_respects_dependency_overrides(
     base_config: AgentConfig,

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -1,14 +1,6 @@
-from pathlib import Path
 
-import sys
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
 
 from config import load_agent_config  # type: ignore  # noqa: E402
-
 
 def test_load_agent_config_returns_defaults() -> None:
     result = load_agent_config({})
@@ -33,13 +25,11 @@ def test_load_agent_config_returns_defaults() -> None:
     assert config.queue_max_size == 20
     assert config.worker_task_timeout_seconds == 300.0
 
-
 def test_load_agent_config_emits_warning_on_invalid_port() -> None:
     result = load_agent_config({"AGENT_WS_PORT": "invalid"})
 
     assert result.config.agent_port == 9000
     assert any("ポート値" in warning for warning in result.warnings)
-
 
 def test_load_agent_config_handles_invalid_move_target() -> None:
     result = load_agent_config({"DEFAULT_MOVE_TARGET": "bad"})
@@ -47,20 +37,17 @@ def test_load_agent_config_handles_invalid_move_target() -> None:
     assert result.config.default_move_target == (0, 64, 0)
     assert any("DEFAULT_MOVE_TARGET" in warning for warning in result.warnings)
 
-
 def test_load_agent_config_handles_invalid_llm_timeout() -> None:
     result = load_agent_config({"LLM_TIMEOUT_SECONDS": "-10"})
 
     assert result.config.llm_timeout_seconds == 30.0
     assert any("タイムアウト値" in warning for warning in result.warnings)
 
-
 def test_load_agent_config_handles_invalid_queue_max_size() -> None:
     result = load_agent_config({"AGENT_QUEUE_MAX_SIZE": "-1"})
 
     assert result.config.queue_max_size == 20
     assert any("キュー上限" in warning for warning in result.warnings)
-
 
 def test_load_agent_config_reads_worker_timeout() -> None:
     result = load_agent_config({"WORKER_TASK_TIMEOUT_SECONDS": "45"})

--- a/tests/test_agent_equip.py
+++ b/tests/test_agent_equip.py
@@ -3,25 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import copy
 
 import pytest
 
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
-
 
 class DummyActions:
     """AgentOrchestrator から呼び出されるアクションを記録するスタブ。"""
@@ -88,13 +77,11 @@ class DummyActions:
         )
         return {"ok": True}
 
-
 @pytest.fixture
 def orchestrator() -> AgentOrchestrator:
     actions = DummyActions()
     memory = Memory()
     return AgentOrchestrator(actions, memory)
-
 
 def test_infer_equip_arguments_recognizes_pickaxe(orchestrator: AgentOrchestrator) -> None:
     """ツルハシ装備指示から pickaxe を推測できることを確認する。"""
@@ -102,13 +89,11 @@ def test_infer_equip_arguments_recognizes_pickaxe(orchestrator: AgentOrchestrato
     result = orchestrator._infer_equip_arguments("渡されたツルハシを装備する")
     assert result == {"tool_type": "pickaxe", "destination": "hand"}
 
-
 def test_infer_equip_arguments_detects_off_hand(orchestrator: AgentOrchestrator) -> None:
     """左手と盾の指示で off-hand 装備が選択されることを検証する。"""
 
     result = orchestrator._infer_equip_arguments("左手に盾を構えておいて")
     assert result == {"tool_type": "shield", "destination": "off-hand"}
-
 
 def test_handle_action_task_dispatches_equip(orchestrator: AgentOrchestrator) -> None:
     """equip カテゴリのステップが equipItem コマンドを発行することをテストする。"""
@@ -134,7 +119,6 @@ def test_handle_action_task_dispatches_equip(orchestrator: AgentOrchestrator) ->
     assert dummy_actions.equip_calls == [
         {"tool_type": "pickaxe", "item_name": None, "destination": "hand"}
     ]
-
 
 def test_handle_equip_reports_barrier_when_pickaxe_missing(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_agent_mine.py
+++ b/tests/test_agent_mine.py
@@ -3,24 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
 from skills import SkillMatch, SkillNode  # type: ignore  # noqa: E402
-
 
 class DummyActions:
     """採掘系テストで Mineflayer とのやり取りを記録するスタブ。"""
@@ -64,7 +53,6 @@ class DummyActions:
         )
         return {"ok": True}
 
-
 @pytest.fixture
 def orchestrator_fixture() -> Tuple[AgentOrchestrator, DummyActions, Memory]:
     """アクションとメモリを差し替えた Orchestrator のテスト用インスタンス。"""
@@ -73,7 +61,6 @@ def orchestrator_fixture() -> Tuple[AgentOrchestrator, DummyActions, Memory]:
     memory = Memory()
     orchestrator = AgentOrchestrator(actions, memory)
     return orchestrator, actions, memory
-
 
 def test_mine_skips_when_suitable_pickaxe_exists(
     orchestrator_fixture: Tuple[AgentOrchestrator, DummyActions, Memory]
@@ -115,7 +102,6 @@ def test_mine_skips_when_suitable_pickaxe_exists(
     assert actions.equip_calls == [
         {"tool_type": "pickaxe", "item_name": None, "destination": "hand"}
     ]
-
 
 def test_mine_continues_when_pickaxe_missing(
     orchestrator_fixture: Tuple[AgentOrchestrator, DummyActions, Memory]
@@ -160,7 +146,6 @@ def test_mine_continues_when_pickaxe_missing(
     ]
     assert actions.equip_calls == []
 
-
 def test_mine_treats_broken_pickaxe_as_missing(
     orchestrator_fixture: Tuple[AgentOrchestrator, DummyActions, Memory]
 ) -> None:
@@ -199,7 +184,6 @@ def test_mine_treats_broken_pickaxe_as_missing(
     assert backlog == []
     assert len(actions.mine_calls) == 1
     assert actions.equip_calls == []
-
 
 class SkillFallbackActions:
     """登録外スキル応答を模倣し、フォールバック処理を検証するためのスタブ。"""
@@ -240,7 +224,6 @@ class SkillFallbackActions:
     ) -> Dict[str, Any]:
         return {"ok": True, "tool_type": tool_type, "item_name": item_name, "destination": destination}
 
-
 class SkillRepositoryStub:
     """SkillMatch を固定で提供し、record_usage 呼び出しを観測するテスト専用リポジトリ。"""
 
@@ -260,7 +243,6 @@ class SkillRepositoryStub:
 
     async def record_usage(self, skill_id: str, *, success: bool) -> None:
         self.record_usage_calls.append((skill_id, success))
-
 
 def test_unregistered_skill_falls_back_to_mining_route() -> None:
     """Mineflayer 側で未登録エラーが返っても採掘ヒューリスティックへ進むことを確認する。"""

--- a/tests/test_agent_perception.py
+++ b/tests/test_agent_perception.py
@@ -2,23 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import sys
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
-
 
 class PassiveActions:
     async def say(self, text: str):  # pragma: no cover - simple stub
         return {"ok": True, "echo": text}
-
 
 def test_perception_snapshot_summary_updates_memory() -> None:
     orchestrator = AgentOrchestrator(PassiveActions(), Memory())

--- a/tests/test_agent_replan.py
+++ b/tests/test_agent_replan.py
@@ -2,19 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pytest
-
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
@@ -24,7 +14,6 @@ from planner import (  # type: ignore  # noqa: E402
     plan,
     reset_plan_priority,
 )
-
 
 class ReplanActions:
     """Mineflayer とのやり取りを模したスタブで再計画フローを観察する。"""
@@ -85,7 +74,6 @@ class ReplanActions:
     async def move_to(self, x: int, y: int, z: int) -> Dict[str, bool]:
         return {"ok": True}
 
-
 class EquipFailureActions:
     """装備失敗シナリオを再現し、インベントリ更新フローを検証するスタブ。"""
 
@@ -131,7 +119,6 @@ class EquipFailureActions:
             "error": "Requested item is not available in inventory",
         }
 
-
 class AutoRecoveryActions:
     """MineDojo 自動リカバリー用の最小アクションスタブ。"""
 
@@ -141,7 +128,6 @@ class AutoRecoveryActions:
     async def say(self, text: str) -> Dict[str, bool]:
         self.say_messages.append(text)
         return {"ok": True}
-
 
 class DummySelfDialogueExecutor:
     def __init__(self) -> None:
@@ -165,7 +151,6 @@ class DummySelfDialogueExecutor:
                 "success": success,
             }
         )
-
 
 def test_mining_failure_triggers_replan(monkeypatch: pytest.MonkeyPatch) -> None:
     """採掘失敗時に障壁通知を挟んで再計画が走ることを統合テストする。"""
@@ -206,7 +191,6 @@ def test_mining_failure_triggers_replan(monkeypatch: pytest.MonkeyPatch) -> None
     assert actions.say_messages[0].startswith("障壁")
     assert any(msg == "代替プランで進めます。" for msg in actions.say_messages)
     assert replan_prompts and "失敗" in replan_prompts[0]
-
 
 def test_equip_failure_refreshes_inventory_and_requests_replan(
     monkeypatch: pytest.MonkeyPatch,
@@ -314,7 +298,6 @@ def test_plan_timeout_returns_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     assert plan_out.resp == "了解しました。"
     assert priority == "high"
 
-
 def test_barrier_timeout_uses_short_message(monkeypatch: pytest.MonkeyPatch) -> None:
     """障壁通知生成がタイムアウトしても短縮メッセージがチャットへ送信される。"""
 
@@ -361,7 +344,6 @@ def test_barrier_timeout_uses_short_message(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert actions.say_messages[0] == expected_message
 
-
 def test_minedojo_autorecovery_runs_for_empty_plan(monkeypatch: pytest.MonkeyPatch) -> None:
     actions = AutoRecoveryActions()
     memory = Memory()
@@ -387,7 +369,6 @@ def test_minedojo_autorecovery_runs_for_empty_plan(monkeypatch: pytest.MonkeyPat
     assert actions.say_messages
     assert dummy_executor.calls
     assert dummy_executor.calls[0]["mission_id"] == "obtain_diamond"
-
 
 def test_minedojo_autorecovery_skips_without_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
     actions = AutoRecoveryActions()

--- a/tests/test_agent_task_classification.py
+++ b/tests/test_agent_task_classification.py
@@ -3,24 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional
 
 import pytest
 
-import sys
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
-
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
 from runtime.rules import ACTION_TASK_RULES  # type: ignore  # noqa: E402
-
 
 @dataclass
 class NullActions:
@@ -34,13 +23,11 @@ class NullActions:
 
         return _noop
 
-
 @pytest.fixture
 def orchestrator() -> AgentOrchestrator:
     """キーワード分類メソッドを検証するためのオーケストレータインスタンス。"""
 
     return AgentOrchestrator(NullActions(), Memory())
-
 
 def legacy_classify(orchestrator: AgentOrchestrator, text: str) -> Optional[str]:
     """旧ロジック（先着順の単純一致）を再現し、新旧差分を比較する。"""
@@ -50,7 +37,6 @@ def legacy_classify(orchestrator: AgentOrchestrator, text: str) -> Optional[str]
         if any(keyword and keyword in normalized for keyword in rule.keywords):
             return category
     return None
-
 
 @pytest.mark.parametrize(
     "text",
@@ -70,7 +56,6 @@ def test_classification_matches_legacy_for_single_category(
         orchestrator, text
     )
 
-
 def test_classification_prioritizes_equip_over_mine(
     orchestrator: AgentOrchestrator,
 ) -> None:
@@ -79,7 +64,6 @@ def test_classification_prioritizes_equip_over_mine(
     text = "採掘に行く前にツルハシを装備して採掘を開始"
     assert legacy_classify(orchestrator, text) == "mine"
     assert orchestrator.task_router.classify_action_task(text) == "equip"
-
 
 def test_classification_handles_punctuated_text(
     orchestrator: AgentOrchestrator,

--- a/tests/test_bridge_client.py
+++ b/tests/test_bridge_client.py
@@ -4,16 +4,11 @@
 from __future__ import annotations
 
 import pathlib
-import sys
 import unittest
 
 import httpx
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT / "python"))
-
 from bridge_client import BridgeClient, BridgeError  # noqa: E402
-
 
 class BridgeClientTest(unittest.TestCase):
     def test_bridge_error_contains_payload_and_status(self) -> None:
@@ -33,7 +28,6 @@ class BridgeClientTest(unittest.TestCase):
         self.assertTrue(err.payload.get("stop"))
 
         client.close()
-
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_bridge_ws.py
+++ b/tests/test_bridge_ws.py
@@ -2,20 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
-from pathlib import Path
 from typing import Any, List, Tuple
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 import bridge_ws  # noqa: E402  # isort:skip
 from bridge_ws import BotBridge  # type: ignore  # noqa: E402  # isort:skip
-
 
 class _RefusingConnector:
     """接続拒否を模倣し、呼び出し回数を数えるテスト専用コネクタ。"""
@@ -29,7 +21,6 @@ class _RefusingConnector:
 
     async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
         return None
-
 
 class _HangingWebSocket:
     """受信を意図的にタイムアウトさせるための擬似 WebSocket。"""
@@ -49,7 +40,6 @@ class _HangingWebSocket:
     async def recv(self) -> str:
         await asyncio.sleep(0.05)
         return "{}"
-
 
 @pytest.mark.anyio
 async def test_connect_retry_and_logging(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -91,7 +81,6 @@ async def test_connect_retry_and_logging(monkeypatch: pytest.MonkeyPatch, caplog
     assert notifications.count(("give_up", 2, "connect_refused")) == 1
     recorded_retries = [item for item in notifications if item[0] == "retry"]
     assert {item[1] for item in recorded_retries} == {1, 2}
-
 
 @pytest.mark.anyio
 async def test_receive_timeout_reports_fault(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_building_plan_processor.py
+++ b/tests/test_building_plan_processor.py
@@ -1,19 +1,11 @@
 # -*- coding: utf-8 -*-
 """building_plan_processor モジュールの単体テスト。"""
 import logging
-from pathlib import Path
-import sys
 from typing import Any, Dict
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from runtime.building_plan_processor import BuildingPlanProcessor
-
 
 class DummyMemory:
     """BuildingPlanProcessor が利用する永続メモリを簡易的に模倣する。"""
@@ -27,14 +19,12 @@ class DummyMemory:
     def set(self, key: str, value: Any) -> None:
         self._store[key] = value
 
-
 class DummyOrchestrator:
     """建築計画用の orchestrator 依存を最小化したスタブ。"""
 
     def __init__(self):
         self.memory = DummyMemory()
         self.logger = logging.getLogger("building-plan-test")
-
 
 def _create_state(step: str) -> Dict[str, Any]:
     return {
@@ -44,7 +34,6 @@ def _create_state(step: str) -> Dict[str, Any]:
         "last_target_coords": (0, 0, 0),
         "active_role": "builder",
     }
-
 
 def test_process_creates_checkpoint_and_backlog_entries():
     orchestrator = DummyOrchestrator()
@@ -68,7 +57,6 @@ def test_process_creates_checkpoint_and_backlog_entries():
     assert state["backlog"][0]["module"] == "building"
     assert "procurement" in state["backlog"][0]
     assert orchestrator.memory.get("building_checkpoint_base_id").startswith("building:")
-
 
 def test_process_marks_resumed_and_updates_placement_snapshot():
     orchestrator = DummyOrchestrator()

--- a/tests/test_cli_agentbridge.py
+++ b/tests/test_cli_agentbridge.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from python.cli import _format_bridge_event, _should_emit_event
 
-
 def test_should_emit_event_filters_by_job_and_level():
     event = {"job_id": "demo", "event_level": "info"}
     assert _should_emit_event(event, job_id="demo", danger_only=False)
@@ -15,7 +14,6 @@ def test_should_emit_event_filters_by_job_and_level():
     assert _should_emit_event(warning_event, job_id="demo", danger_only=True)
     info_event = {"job_id": "demo", "event_level": "info"}
     assert not _should_emit_event(info_event, job_id="demo", danger_only=True)
-
 
 def test_format_bridge_event_supports_text_and_json():
     event = {

--- a/tests/test_langfuse_tracer.py
+++ b/tests/test_langfuse_tracer.py
@@ -1,12 +1,6 @@
 from pathlib import Path
-import sys
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
 
 from runtime.minedojo import MineDojoSelfDialogueExecutor  # type: ignore  # noqa: E402
 from planner import ReActStep  # type: ignore  # noqa: E402
@@ -16,7 +10,6 @@ from services.minedojo_client import (  # type: ignore  # noqa: E402
     MineDojoMission,
 )
 from utils.langfuse_tracer import ThoughtActionObservationTracer  # type: ignore  # noqa: E402
-
 
 class StubObservation:
     """Langfuse Observation の update/end を記録するテストダブル。"""
@@ -34,7 +27,6 @@ class StubObservation:
         self.ended = True
         return self
 
-
 class StubLangfuseClient:
     """Langfuse SDK 呼び出しを記録するシンプルなテストダブル。"""
 
@@ -50,7 +42,6 @@ class StubLangfuseClient:
     def flush(self) -> None:
         self.flushed = True
 
-
 class StubActions:
     """Mineflayer 連携の代わりに呼び出し内容を記録するダミー実装。"""
 
@@ -65,7 +56,6 @@ class StubActions:
     async def invoke_skill(self, skill_id: str, *, context: str | None = None):  # type: ignore[override]
         self.invoked.append({"skill_id": skill_id, "context": context})
         return {"ok": True, "skill_id": skill_id, "context": context}
-
 
 class StubMineDojoClient(MineDojoClient):
     """fetch 系のみスタブ化した MineDojo クライアント。"""
@@ -101,7 +91,6 @@ class StubMineDojoClient(MineDojoClient):
     async def record_mission_outcome(self, mission_id: str, *, outcome):  # type: ignore[override]
         return {"mission_id": mission_id, "outcome": outcome}
 
-
 def test_thought_action_observation_tracer_records_runs() -> None:
     client = StubLangfuseClient()
     tracer = ThoughtActionObservationTracer(
@@ -121,7 +110,6 @@ def test_thought_action_observation_tracer_records_runs() -> None:
     assert client.created_observations[0].payload["name"] == "demo"
     assert client.created_observations[0].updates, "Langfuse クライアントへ update が送信されていません"
     assert client.flushed is True
-
 
 @pytest.mark.anyio
 async def test_self_dialogue_executor_updates_skill_and_invokes(tmp_path: Path) -> None:

--- a/tests/test_langgraph_scenarios.py
+++ b/tests/test_langgraph_scenarios.py
@@ -5,20 +5,12 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from pathlib import Path
+import sys
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
-import sys
-
 pytest.importorskip("langgraph")
-
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
@@ -33,7 +25,6 @@ from planner import (  # type: ignore  # noqa: E402
 from runtime.action_graph import UnifiedAgentGraph  # type: ignore  # noqa: E402
 from langgraph_state import UnifiedPlanState  # type: ignore  # noqa: E402
 
-
 class MoveFailureActions:
     """移動アクションを常に失敗させるテスト用スタブ。"""
 
@@ -42,7 +33,6 @@ class MoveFailureActions:
 
     async def move_to(self, x: int, y: int, z: int) -> Dict[str, Any]:
         return {"ok": False, "error": "path blocked"}
-
 
 class NoOpActions:
     """行動系コマンドをすべて成功扱いで無視するスタブ。"""
@@ -79,20 +69,17 @@ class NoOpActions:
     ) -> Dict[str, Any]:
         return {"ok": True, "ores": list(ore_names)}
 
-
 @pytest.fixture
 def orchestrator_with_failure() -> AgentOrchestrator:
     actions = MoveFailureActions()
     memory = Memory()
     return AgentOrchestrator(actions, memory)
 
-
 @pytest.fixture
 def orchestrator_noop() -> AgentOrchestrator:
     actions = NoOpActions()
     memory = Memory()
     return AgentOrchestrator(actions, memory)
-
 
 def test_action_graph_reports_move_failure(orchestrator_with_failure: AgentOrchestrator) -> None:
     backlog: List[Dict[str, str]] = []
@@ -111,7 +98,6 @@ def test_action_graph_reports_move_failure(orchestrator_with_failure: AgentOrche
     assert updated is None
     assert failure is not None and "blocked" in failure
     assert backlog == []
-
 
 def test_action_graph_parallel_modules_do_not_share_backlog(orchestrator_noop: AgentOrchestrator) -> None:
     backlog: List[Dict[str, str]] = []
@@ -137,7 +123,6 @@ def test_action_graph_parallel_modules_do_not_share_backlog(orchestrator_noop: A
     modules = {entry.get("module") for entry in backlog}
     assert modules == {"building", "defense"}
     assert len(backlog) == 2
-
 
 def test_action_directive_overrides_category(
     monkeypatch: pytest.MonkeyPatch, orchestrator_noop: AgentOrchestrator
@@ -175,7 +160,6 @@ def test_action_directive_overrides_category(
 
     assert recorded["category"] == "mine"
     assert recorded["explicit_coords"] == (5, 60, -3)
-
 
 def test_plan_graph_priority_updates(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyResponse:
@@ -221,7 +205,6 @@ def test_plan_graph_priority_updates(monkeypatch: pytest.MonkeyPatch) -> None:
     assert asyncio.run(get_plan_priority()) == "normal"
 
     asyncio.run(reset_plan_priority())
-
 
 def test_low_confidence_triggers_pre_action_review(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyResponse:
@@ -290,7 +273,6 @@ def test_low_confidence_triggers_pre_action_review(monkeypatch: pytest.MonkeyPat
     assert result.backlog
     assert result.backlog[-1]["label"] == "自動確認"
 
-
 def test_react_loop_logs_observations(
     caplog: pytest.LogCaptureFixture, orchestrator_noop: AgentOrchestrator
 ) -> None:
@@ -326,7 +308,6 @@ def test_react_loop_logs_observations(
     assert "X=" in react_logs[1]["observation"] or "報告" in react_logs[1]["observation"]
     assert plan_out.react_trace[0].observation.startswith("移動成功")
 
-
 def test_unified_graph_success(monkeypatch: pytest.MonkeyPatch, orchestrator_noop: AgentOrchestrator) -> None:
     async def stub_plan(_: str, __: Dict[str, Any]) -> PlanOut:
         return PlanOut(plan=["南へ移動"], resp="了解しました。", intent="move")
@@ -344,7 +325,6 @@ def test_unified_graph_success(monkeypatch: pytest.MonkeyPatch, orchestrator_noo
     events = result.get("structured_events") or []
     labels = {event.get("step_label") for event in events}
     assert {"analyze_intent", "generate_plan", "dispatch_action", "mineflayer_node"}.issubset(labels)
-
 
 def test_unified_graph_plan_failure(monkeypatch: pytest.MonkeyPatch, orchestrator_noop: AgentOrchestrator) -> None:
     async def failing_plan(_: str, __: Dict[str, Any]) -> PlanOut:

--- a/tests/test_move_handler.py
+++ b/tests/test_move_handler.py
@@ -1,20 +1,12 @@
 # -*- coding: utf-8 -*-
 """move_handler モジュールの単体テスト。"""
 import asyncio
-from pathlib import Path
-import sys
 from typing import Any, Dict, Optional, Tuple
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from services.movement_service import MovementResult
 from runtime.move_handler import handle_move
-
 
 class DummyOrchestrator:
     """移動ハンドラが参照する orchestrator API を最小限で模倣するテスト用スタブ。"""
@@ -53,14 +45,12 @@ class DummyOrchestrator:
 
         return _StubMovementService()
 
-
 class MemoryStub:
     def __init__(self, data: Optional[Dict[str, Any]] = None) -> None:
         self._data = data or {}
 
     def get(self, key: str, default: Any = None) -> Any:
         return self._data.get(key, default)
-
 
 class FollowOrchestrator(DummyOrchestrator):
     """追従コマンド経由で move_to_player を検証するスタブ。"""
@@ -85,7 +75,6 @@ class FollowOrchestrator(DummyOrchestrator):
 
         self.actions = _Actions(self)
 
-
 def test_handle_move_uses_explicit_coordinates():
     orchestrator = DummyOrchestrator()
     state: Dict[str, Any] = {
@@ -102,7 +91,6 @@ def test_handle_move_uses_explicit_coordinates():
     assert result == {"handled": True, "updated_target": (1, 2, 3), "failure_detail": None}
     assert orchestrator._move_requests == ((1, 2, 3),)
     assert orchestrator._reported == {}
-
 
 def test_handle_move_falls_back_to_default_and_reports_barrier():
     orchestrator = DummyOrchestrator()
@@ -124,7 +112,6 @@ def test_handle_move_falls_back_to_default_and_reports_barrier():
     assert orchestrator._move_requests == ((5, 5, 5),)
     assert "どこかへ移動" in orchestrator._reported
     assert "既定座標" in orchestrator._reported["どこかへ移動"]
-
 
 def test_handle_move_adds_backlog_when_hungry_and_role_changed():
     orchestrator = DummyOrchestrator()
@@ -152,7 +139,6 @@ def test_handle_move_adds_backlog_when_hungry_and_role_changed():
     role_entry = next(item for item in state["backlog"] if item["category"] == "role")
     assert role_entry["role"] == "builder"
 
-
 def test_handle_move_returns_failure_when_move_rejected():
     orchestrator = DummyOrchestrator()
     orchestrator._extracted = (0, 0, 0)
@@ -171,7 +157,6 @@ def test_handle_move_returns_failure_when_move_rejected():
     assert result["handled"] is False
     assert result["updated_target"] == (7, 7, 7)
     assert "blocked" in result["failure_detail"]
-
 
 def test_handle_move_follows_last_requester_when_state_missing_target():
     orchestrator = FollowOrchestrator()

--- a/tests/test_reflexion_memory.py
+++ b/tests/test_reflexion_memory.py
@@ -2,18 +2,10 @@
 """Reflexion メモリの永続化とサマリ生成ロジックのユニットテスト。"""
 
 from __future__ import annotations
-
 from pathlib import Path
-import sys
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
 
 from memory import Memory  # type: ignore  # noqa: E402
 from services.reflection_store import ReflectionStore  # type: ignore  # noqa: E402
-
 
 def test_reflection_memory_persistence(tmp_path: Path) -> None:
     """反省ログの保存と再読み込みが行えることを確認する。"""
@@ -47,7 +39,6 @@ def test_reflection_memory_persistence(tmp_path: Path) -> None:
 
     prompt_logs = reloaded.export_reflections_for_prompt(task_signature=signature, limit=1)
     assert prompt_logs[0]["improvement"] == prompt
-
 
 def test_reflection_signature_normalization(tmp_path: Path) -> None:
     """ステップ文字列の空白揺れが署名生成で吸収されることを確認する。"""

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -5,26 +5,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from pathlib import Path
-import sys
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-STUB_DIR = PROJECT_ROOT / "tests" / "stubs"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-if str(STUB_DIR) not in sys.path:
-    sys.path.insert(0, str(STUB_DIR))
 
 from agent import AgentOrchestrator  # type: ignore  # noqa: E402
 from bridge_client import BRIDGE_RETRY, BridgeClient, BridgeError  # type: ignore  # noqa: E402
 from memory import Memory  # type: ignore  # noqa: E402
 from utils import setup_logger  # type: ignore  # noqa: E402
 from utils.logging import StructuredLogFormatter  # type: ignore  # noqa: E402
-
 
 class PassiveActions:
     """Mineflayer 呼び出しをスタブ化した受動的アクション群。"""
@@ -53,7 +42,6 @@ class PassiveActions:
     ) -> Dict[str, Any]:
         return {"ok": True, "ores": list(ore_names)}
 
-
 def _run_build_node(
     orchestrator: AgentOrchestrator,
     backlog: List[Dict[str, str]],
@@ -69,7 +57,6 @@ def _run_build_node(
         )
 
     return asyncio.run(runner())
-
 
 def test_structured_log_outputs_json() -> None:
     logger = setup_logger("test.struct")
@@ -95,7 +82,6 @@ def test_structured_log_outputs_json() -> None:
     assert payload["event_level"] == "progress"
     assert payload["context"]["foo"] == "bar"
     assert payload["context"]["count"] == 2
-
 
 def test_building_recovery_logs_recovery_event(caplog: pytest.LogCaptureFixture) -> None:
     actions = PassiveActions()
@@ -130,7 +116,6 @@ def test_building_recovery_logs_recovery_event(caplog: pytest.LogCaptureFixture)
     context = getattr(record, "structured_context", {})
     assert context.get("resumed") is True
     assert context.get("phase") in {"placement", "inspection"}
-
 
 def test_bridge_client_logs_fault_on_disconnect(
     caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_task_router.py
+++ b/tests/test_task_router.py
@@ -8,17 +8,8 @@ import logging
 
 import pytest
 
-import sys
-from pathlib import Path
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PYTHON_DIR = PROJECT_ROOT / "python"
-if str(PYTHON_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_DIR))
-
 from orchestrator.action_analyzer import ActionAnalyzer  # type: ignore  # noqa: E402
 from orchestrator.task_router import TaskRouter  # type: ignore  # noqa: E402
-
 
 @dataclass
 class StubChatPipeline:
@@ -65,7 +56,6 @@ class StubChatPipeline:
     ) -> None:
         self.detection_calls.append((list(reports), already_responded))
 
-
 @dataclass
 class StubSkillDetection:
     """SkillDetectionCoordinator を置き換える簡易スタブ。"""
@@ -102,7 +92,6 @@ class StubSkillDetection:
     ) -> Tuple[bool, Optional[str]]:
         return self.exploration_response
 
-
 @pytest.fixture()
 def task_router() -> TaskRouter:
     """ActionAnalyzer とスタブ依存から TaskRouter を構築する。"""
@@ -127,12 +116,10 @@ def task_router() -> TaskRouter:
     router._skill_detection = skill_detection  # type: ignore[attr-defined]
     return router
 
-
 def test_classify_detection_task_uses_keyword(task_router: TaskRouter) -> None:
     """キーワードに基づいて検出タスクが適切に分類されることを確認する。"""
 
     assert task_router.classify_detection_task("現在位置を教えて") == "player_position"
-
 
 @pytest.mark.anyio
 async def test_perform_detection_task_reports_barrier(task_router: TaskRouter) -> None:
@@ -145,7 +132,6 @@ async def test_perform_detection_task_reports_barrier(task_router: TaskRouter) -
     assert task_router._barrier_calls == [  # type: ignore[attr-defined]
         ("現在位置の確認", "ステータス取得に失敗しました（timeout）。")
     ]
-
 
 @pytest.mark.anyio
 async def test_handle_backlog_and_reports_delegate(task_router: TaskRouter) -> None:
@@ -163,7 +149,6 @@ async def test_handle_backlog_and_reports_delegate(task_router: TaskRouter) -> N
     assert task_router._chat_pipeline.detection_calls == [  # type: ignore[attr-defined]
         (reports, True)
     ]
-
 
 @pytest.mark.anyio
 async def test_skill_delegation_and_pickaxe_selection(task_router: TaskRouter) -> None:

--- a/tests/test_tunnel_direction.py
+++ b/tests/test_tunnel_direction.py
@@ -8,7 +8,6 @@ import pytest
 from python.modes.tunnel import TunnelSection
 from python.modes.tunnel_direction import infer_tunnel_direction
 
-
 class DirectionBridgeStub:
     """Bridge stub that flags hazards based on axis direction."""
 
@@ -55,7 +54,6 @@ class DirectionBridgeStub:
             return "north"
         return "origin"
 
-
 def test_infer_direction_prefers_safe_axis():
     anchor = {"x": 0, "y": 64, "z": 0}
     # East contains liquid, North includes player-placed blocks. South/West are safe.
@@ -68,7 +66,6 @@ def test_infer_direction_prefers_safe_axis():
     assert result.direction in {(0, 0, 1), (-1, 0, 0)}
     assert result.score > 0
     assert "liquid" not in result.hazards
-
 
 def test_infer_direction_raises_when_all_hazardous():
     anchor = {"x": 0, "y": 64, "z": 0}

--- a/tests/test_tunnel_mode.py
+++ b/tests/test_tunnel_mode.py
@@ -7,17 +7,12 @@ import asyncio
 import unittest
 
 import pathlib
-import sys
-
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT / "python"))
 
 from bridge_client import BridgeError
 from heuristics.artificial_filters import build_mining_mask
 from modes import tunnel
 from modes.tunnel import TunnelMode, TunnelSection
 from tests.stubs.bridge_stub import BridgeStub
-
 
 class FakeActions:
     """Actions の非同期メソッドを記録するテストダブル。"""
@@ -33,7 +28,6 @@ class FakeActions:
     async def place_torch(self, position):  # type: ignore[no-untyped-def]
         self.torches.append(dict(position))
         return {"ok": True}
-
 
 class MiningMaskTest(unittest.TestCase):
     def test_build_mining_mask_filters_conditions(self) -> None:
@@ -67,7 +61,6 @@ class MiningMaskTest(unittest.TestCase):
         ]
         mask = build_mining_mask(evaluations, cp_results)
         self.assertEqual(mask, [True, False, False])
-
 
 class TunnelModeTest(unittest.IsolatedAsyncioTestCase):
     async def test_tunnel_progress_and_torch(self) -> None:
@@ -122,7 +115,6 @@ class TunnelModeTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(bridge.started)
         self.assertTrue(bridge.stopped)
         self.assertLessEqual(bridge.advanced_steps, 1)
-
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
### Motivation
- Python 実行経路が `PYTHONPATH`/sys.path 側のハックに依存しているため、パッケージ化して安定した import 経路を正本化する必要があった。 
- 開発者と CI の再現性を高めるために `pip install -e .` 相当の editable install を導入して依存解決と起動を安定化する。 
- テスト群が一貫してインストール済みモジュール経由で動作するようにして、以降の Phase（src レイアウト移行など）へ安全に繋げる。 

### Description
- `pyproject.toml` を追加して setuptools ベースの installable package を定義し、`mc-bot-agent` エントリポイントを `project.scripts` に登録した。 
- 新しい entrypoint `python/mc_bot_agent_entrypoint.py` を追加し、`python/__main__.py` をこの起動モジュールを呼ぶだけに簡素化して `sys.path` 挿入を除去した。 
- 起動 / watch / setup スクリプトを更新して `-m mc_bot_agent_entrypoint` と editable install（`pip install -e .`）を前提にした流れにした（`scripts/setup-python-env.sh`、`scripts/run-python-agent.sh`、`scripts/run-python-agent-watch.sh`）。 
- CI (`.github/workflows/ci.yml`) の Python job に `python -m pip install -e .` を追加して、テスト実行前にパッケージをインストールするようにした。 
- テスト群のファイルから個別の `sys.path` / `PYTHON_DIR` 挿入を削除し、必要な箇所へは欠落 import（例: `from pathlib import Path`）を明示的に追加してパッケージ化後に収まるよう修正した。 
- ドキュメントと進捗管理を更新し、`docs/refactor/phase2.md` と `docs/refactor/progress.json` を Phase 2 完了へ反映し、`README.md` の起動手順を同期した。 

### Testing
- `python -m pip install -e .` を実行して editable install が成功したことを確認した。 
- `python -m pytest tests/test_langgraph_scenarios.py` を実行して該当シナリオ群の通過を確認した（`8 passed`）。 
- `python -m pytest tests` を実行して全テストスイートを実行し、`88 passed` で完了（ローカル OpenTelemetry exporter へ接続できない警告が出たが、テスト終了コードは成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38ddc1f40832cb0f433e8f78d4375)