### PR TITLE
Phase3着手: envテンプレートをdev/prod分離してREADMEを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,22 @@ cd C:\mc\paper
 java -Xms4G -Xmx4G -jar .\paper.jar --nogui
 ```
 
-開発中は `server.properties` の `online-mode=false` を推奨します。
+開発中は `server.properties` の `online-mode=false` を推奨します（本番は `online-mode=true` と `AUTH_MODE=microsoft` を推奨）。
 
 ### 2) `.env` 作成（プロジェクトルート）
 
 ```bash
-cp env.example .env
+cp env.dev.example .env
 ```
 
 最低限 `OPENAI_API_KEY` と、Minecraft 接続先（`MC_HOST` / `MC_PORT`）を設定してください。
-`env.example` の既定値はローカル実行向けに `127.0.0.1` を向いており、Docker Compose 実行時は service 名へ自動で上書きされます。
+`env.dev.example` はローカル開発向け既定値、`env.prod.example` は本番相当の安全側既定値です。Docker Compose 実行時は service 名への上書きが一部適用されます。
+
+### 環境テンプレートの使い分け
+
+- 開発: `cp env.dev.example .env`
+- 本番相当: `cp env.prod.example .env`
+- 互換: `env.example` は過渡期のため残置（将来削除予定）
 
 ### 3) Node（Mineflayer）起動
 
@@ -155,7 +161,7 @@ make build-bridge
 Python と Node を同時にホットリロードで動かしたい場合:
 
 ```bash
-cp env.example .env  # まだ .env が無い場合
+cp env.dev.example .env  # まだ .env が無い場合
 docker compose up --build
 ```
 
@@ -170,7 +176,7 @@ docker compose -f docker-compose.yml -f docker-compose.host-services.yml up --bu
 
 ## 設定（.env）
 
-`.env` は `env.example` を一次情報として扱ってください。ここでは「運用でよく触る項目」と「落とし穴」を要約します。
+`.env` は用途別テンプレートを正本として扱ってください。開発は `env.dev.example`、本番相当は `env.prod.example` を使用します。互換のため `env.example` は暫定的に残しています。
 
 ### OpenAI / プランナー
 

--- a/docs/refactor/phase3.md
+++ b/docs/refactor/phase3.md
@@ -1,0 +1,21 @@
+## Phase 3 進捗報告（Slice 1: env 分離）
+- 変更概要:
+  - 開発向け/本番相当向けの環境テンプレートを分離し、`env.dev.example` と `env.prod.example` を追加。
+  - `env.example` は互換レイヤとして残しつつ、将来削除予定であることを明記。
+  - README のセットアップ手順を用途別テンプレート参照に更新。
+- 主な変更ファイル:
+  - `env.dev.example`
+  - `env.prod.example`
+  - `env.example`
+  - `README.md`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - 既存の `cp env.example .env` でも起動可能だが、推奨フローは `env.dev.example` / `env.prod.example` へ移行。
+- 実行したコマンド:
+  - `bash scripts/setup-python-env.sh`
+  - `. .venv/bin/activate && python -m pytest tests`
+- テスト結果:
+  - 成功（既存回帰の範囲で影響なし）。
+- 残課題:
+  - transport envelope 導入（契約スキーマ追加、Node/Python validator 統一）。
+  - 旧 ad-hoc payload の legacy adapter 化と deprecation ログ整備。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,6 +1,6 @@
 {
-  "updated_at": "2026-04-18",
-  "current_phase": 2,
+  "updated_at": "2026-04-19",
+  "current_phase": 3,
   "phases": [
     {
       "phase": 0,
@@ -32,7 +32,12 @@
     {
       "phase": 3,
       "name": "設定分離と transport envelope 統一",
-      "status": "pending"
+      "status": "in_progress",
+      "artifacts": [
+        "env.dev.example",
+        "env.prod.example",
+        "docs/refactor/phase3.md"
+      ]
     },
     {
       "phase": 4,

--- a/env.dev.example
+++ b/env.dev.example
@@ -1,7 +1,3 @@
-# Deprecated compatibility template.
-# 新規セットアップでは `env.dev.example` (開発) または `env.prod.example` (本番相当) を利用してください。
-# 互換性維持のため当面は残していますが、将来削除予定です。
-
 # OpenAI
 OPENAI_API_KEY=sk-xxxxxxx
 # OPENAI_BASE_URL はスキーム付きで指定してください（例: https://api.openai.com/v1）。

--- a/env.prod.example
+++ b/env.prod.example
@@ -1,9 +1,9 @@
-# Deprecated compatibility template.
-# 新規セットアップでは `env.dev.example` (開発) または `env.prod.example` (本番相当) を利用してください。
-# 互換性維持のため当面は残していますが、将来削除予定です。
+# Production-oriented environment template (safe defaults)
+# このファイルは本番相当の安全側デフォルトを提供します。
+# 実運用時は値を埋めたうえで `.env` へコピーして利用してください。
 
 # OpenAI
-OPENAI_API_KEY=sk-xxxxxxx
+OPENAI_API_KEY=
 # OPENAI_BASE_URL はスキーム付きで指定してください（例: https://api.openai.com/v1）。
 # スキームが無い場合は http:// が自動補完されます。
 OPENAI_BASE_URL=
@@ -29,7 +29,7 @@ LANGFUSE_TAGS=self-dialogue,minedojo
 # ローカル実行では 127.0.0.1 を既定にする。Docker Compose 起動時は docker-compose.yml が
 # COMPOSE_WS_URL の既定値として service 名へ自動で上書きする。
 WS_URL=ws://127.0.0.1:8765
-WS_HOST=0.0.0.0
+WS_HOST=127.0.0.1
 WS_PORT=8765
 
 # WebSocket (Node -> Python)
@@ -38,7 +38,7 @@ WS_PORT=8765
 # 接続先には python-agent（Docker）や host.docker.internal / 127.0.0.1 など到達可能なホストを指定する。
 # macOS / Windows の Docker Desktop では host.docker.internal がそのまま使える。
 # Linux で Compose コンテナからホストへ接続する場合は docker-compose.host-services.yml を重ねる。
-AGENT_WS_HOST=0.0.0.0
+AGENT_WS_HOST=127.0.0.1
 AGENT_WS_PORT=9000
 AGENT_WS_URL=ws://127.0.0.1:9000
 AGENT_WS_CONNECT_TIMEOUT_MS=5000
@@ -58,11 +58,11 @@ DEFAULT_MOVE_TARGET=0,64,0
 STRUCTURED_EVENT_HISTORY_LIMIT=10
 PERCEPTION_HISTORY_LIMIT=5
 # ブラウザから内部状態を確認するためのダッシュボード HTTP サーバー設定。
-DASHBOARD_ENABLED=true
+DASHBOARD_ENABLED=false
 DASHBOARD_HOST=127.0.0.1
 DASHBOARD_PORT=9100
 # Bearer トークンで保護したい場合に指定。未設定なら無認証。
-# DASHBOARD_ACCESS_TOKEN=change-me
+DASHBOARD_ACCESS_TOKEN=replace-with-long-random-token
 # Mineflayer 側で周囲認知に利用するスキャン設定
 PERCEPTION_ENTITY_RADIUS=12
 PERCEPTION_BLOCK_RADIUS=4
@@ -107,7 +107,7 @@ MC_RECONNECT_DELAY_MS=5000
 BRIDGE_URL=http://127.0.0.1:19071
 # macOS / Windows の Docker Desktop では host.docker.internal が既定で解決される。
 # Linux では docker-compose.host-services.yml を重ねるか、到達可能なホスト IP を明示する。
-BRIDGE_API_KEY=CHANGE_ME
+BRIDGE_API_KEY=
 BRIDGE_HTTP_TIMEOUT=3.0
 BRIDGE_HTTP_RETRY=3
 BRIDGE_EVENT_STREAM_ENABLED=true
@@ -118,7 +118,7 @@ BRIDGE_EVENT_STREAM_RECONNECT_DELAY=3.0
 # OTLP コレクターのエンドポイント。未設定時は http://localhost:4318 を想定する。
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 # Collector が無い環境では false にすると送信を無効化できる。
-OTEL_EXPORTER_OTLP_ENABLED=true
+OTEL_EXPORTER_OTLP_ENABLED=false
 # トレースのサンプリング率 (0.0～1.0)。1.0 で全件出力。
 OTEL_TRACES_SAMPLER_RATIO=1.0
 # Mineflayer 側のサービス名とデプロイ環境。Collector 上のフィルタリングに活用する。
@@ -148,5 +148,5 @@ TUNNEL_LIQUIDS_STOP=true
 TUNNEL_WINDOW_LENGTH=8
 
 # Bot Auth / Identity
-BOT_USERNAME=HelperBot
-AUTH_MODE=offline
+BOT_USERNAME=
+AUTH_MODE=microsoft


### PR DESCRIPTION
### Motivation
- 開発・本番で安全側の既定値を分離して誤設定リスクを下げ、Phase 3 の `env` 分離要件を満たすため。 
- 既存の `env.example` を即時置換せず互換レイヤとして残しつつ移行案内を明示することで既存ワークフローを壊さないようにするため.

### Description
- 新規に `env.dev.example`（開発向け既定）と `env.prod.example`（本番相当の安全側既定）を追加した。 
- `README.md` の `.env` 作成/Compose/セットアップ手順を `env.dev.example` / `env.prod.example` を正本とする説明に更新した。 
- 互換目的で `env.example` の先頭に注意書きを追加して過渡期であることを明示した。 
- 進捗記録として `docs/refactor/phase3.md` を追加し、`docs/refactor/progress.json` を `current_phase: 3` / `in_progress` に更新した。 

### Testing
- 実行した `bash scripts/setup-python-env.sh` は成功し、開発用仮想環境とパッケージのインストールが完了した（自動化済み）。 
- 仮想環境を有効化した上での `python -m pytest tests` は `88 passed` で全テストが成功した（OTLP export の接続警告は発生したがテストは成功）。 
- 仮想環境未有効状態での `python -m pytest tests` はモジュール解決で失敗したため、セットアップ手順の順序（`setup-python-env.sh` → 仮想環境有効化 → `pytest`）を README に従って実行することを想定している。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4abdc5744832cbe37a84dbd41dd73)