### PR TITLE
transport: transport envelope v1 を導入し Node/Python 互換受信を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ docker compose -f docker-compose.yml -f docker-compose.host-services.yml up --bu
 - **`AGENT_WS_HOST` / `AGENT_WS_PORT`**: Python エージェントの **待受**
 - **`AGENT_WS_URL`**: Node（Mineflayer）が接続する **Python 側の接続先**
   - `0.0.0.0` は待受専用です。接続先には `127.0.0.1` / `host.docker.internal` / `python-agent`（Compose）等、到達可能なホスト名を指定してください。
+- transport payload は `contracts/transport-envelope.schema.json` の envelope（`version`, `trace_id`, `run_id`, `message_id`, `kind`, `name`, `body`）を正本として扱います。
+- 旧 `{type, args}` 形式は互換レイヤで受信可能ですが、deprecation ログを出す暫定運用です。
 
 ### Minecraft / Mineflayer
 

--- a/contracts/transport-envelope.schema.json
+++ b/contracts/transport-envelope.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/contracts/transport-envelope.schema.json",
+  "title": "TransportEnvelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "trace_id",
+    "run_id",
+    "message_id",
+    "timestamp",
+    "source",
+    "kind",
+    "name",
+    "body"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^v[0-9]+$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "message_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["command", "event", "status", "error"]
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "body": {
+      "type": "object"
+    },
+    "auth": {
+      "type": ["object", "null"]
+    }
+  }
+}

--- a/docs/refactor/phase3.md
+++ b/docs/refactor/phase3.md
@@ -19,3 +19,35 @@
 - 残課題:
   - transport envelope 導入（契約スキーマ追加、Node/Python validator 統一）。
   - 旧 ad-hoc payload の legacy adapter 化と deprecation ログ整備。
+
+## Phase 3 完了報告（Slice 2: transport envelope 導入）
+- 変更概要:
+  - `contracts/transport-envelope.schema.json` を追加し、Node/Python 間の message contract を versioned envelope (`v1`) に統一。
+  - Python (`bridge_ws.py`, `runtime/websocket_server.py`) で送受信時の envelope 生成/検証を導入。
+  - Node (`runtime/server.ts`, `runtime/services/chatBridge.ts`, `runtime/agentBridge.ts`) で envelope 検証と legacy payload adapter を導入。
+- 主な変更ファイル:
+  - `contracts/transport-envelope.schema.json`
+  - `python/runtime/transport_envelope.py`
+  - `python/bridge_ws.py`
+  - `python/runtime/websocket_server.py`
+  - `node-bot/runtime/transportEnvelope.ts`
+  - `node-bot/runtime/server.ts`
+  - `node-bot/runtime/services/chatBridge.ts`
+  - `node-bot/runtime/agentBridge.ts`
+  - `README.md`
+- 互換性影響:
+  - 新規送信は envelope 形式に移行。
+  - 旧 `{type,args}` は受信側 adapter で暫定受理し、deprecation log を出力。
+- 実行したコマンド:
+  - `bash scripts/setup-python-env.sh`
+  - `. .venv/bin/activate && python -m pytest tests/test_actions_payloads.py`
+  - `cd node-bot && npm ci`
+  - `cd node-bot && npm test`
+  - `cd node-bot && npm run build`
+- テスト結果:
+  - Python unit test は成功。
+  - Node 系コマンドは実行環境 Node v20.19.6 のため engine 不一致（要求 Node >=22）で失敗。
+- 残課題:
+  - chat 転送の one-shot WebSocket を長寿命接続クライアントへ統合する。
+  - Bridge plugin 経路を含む envelope 適用範囲の拡張。
+

--- a/node-bot/runtime/agentBridge.ts
+++ b/node-bot/runtime/agentBridge.ts
@@ -2,7 +2,8 @@ import { SpanStatusCode, type Counter, type Tracer } from '@opentelemetry/api';
 import { WebSocket } from 'ws';
 
 import { runWithSpan } from './telemetryRuntime.js';
-import type { AgentBridgeSessionState, AgentEventEnvelope, MultiAgentEventPayload } from './types.js';
+import { buildEnvelope } from './transportEnvelope.js';
+import type { AgentBridgeSessionState, MultiAgentEventPayload } from './types.js';
 
 export type StructuredLogLevel = 'info' | 'warn' | 'error';
 
@@ -225,7 +226,12 @@ export class AgentBridge {
   }
 
   private async sendBatch(batch: MultiAgentEventPayload[]): Promise<void> {
-    const envelope: AgentEventEnvelope = { type: 'agentEvent', args: { events: batch } };
+    const envelope = buildEnvelope({
+      source: 'node-bot',
+      kind: 'event',
+      name: 'agentEvent',
+      body: { type: 'agentEvent', args: { events: batch } },
+    });
     const startedAt = Date.now();
     const maxAttempts = Math.max(1, this.config.maxRetries + 1);
 
@@ -255,7 +261,7 @@ export class AgentBridge {
     }
   }
 
-  private sendThroughActiveSession(payload: AgentEventEnvelope): Promise<void> {
+  private sendThroughActiveSession(payload: Record<string, unknown>): Promise<void> {
     const session = this.socket;
     if (!session || this.state !== 'connected' || session.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error('agent bridge is not connected'));

--- a/node-bot/runtime/server.ts
+++ b/node-bot/runtime/server.ts
@@ -5,6 +5,7 @@ import { WebSocketServer, WebSocket, type RawData } from 'ws';
 import { SpanStatusCode, type Tracer } from '@opentelemetry/api';
 
 import { runWithSpan } from './telemetryRuntime.js';
+import { adaptLegacyCommandPayload, validateEnvelope } from './transportEnvelope.js';
 import type { CommandPayload, CommandResponse } from './types.js';
 
 export interface CommandServerConfig {
@@ -19,7 +20,23 @@ export interface CommandServerDependencies {
 
 function parseCommand(raw: RawData): CommandPayload | null {
   try {
-    return JSON.parse(raw.toString()) as CommandPayload;
+    const parsed = JSON.parse(raw.toString()) as unknown;
+    const envelope = validateEnvelope(parsed);
+    if (envelope) {
+      if (envelope.kind !== 'command') {
+        console.warn('[WS] unsupported envelope kind', { kind: envelope.kind, name: envelope.name });
+        return null;
+      }
+      return envelope.body as CommandPayload;
+    }
+
+    const legacy = adaptLegacyCommandPayload(parsed);
+    if (legacy) {
+      console.warn('[WS] legacy payload detected; wrap into transport envelope', { name: legacy.name });
+      return legacy.body as CommandPayload;
+    }
+
+    return null;
   } catch (error) {
     console.error('[WS] invalid payload', error);
     return null;

--- a/node-bot/runtime/services/chatBridge.ts
+++ b/node-bot/runtime/services/chatBridge.ts
@@ -1,7 +1,8 @@
 import type { Bot } from 'mineflayer';
 import { WebSocket } from 'ws';
 
-import type { CommandPayload, CommandResponse } from '../types.js';
+import { buildEnvelope } from '../transportEnvelope.js';
+import type { CommandResponse } from '../types.js';
 
 export type ChatBridgeLogger = (level: 'info' | 'warn' | 'error', message: string, context?: Record<string, unknown>) => void;
 
@@ -105,10 +106,15 @@ export class ChatBridge {
    */
   private async forwardChatToAgent(username: string, message: string): Promise<void> {
     return new Promise<void>((resolve) => {
-      const payload = {
-        type: 'chat',
-        args: { username, message },
-      } satisfies CommandPayload;
+      const payload = buildEnvelope({
+        source: 'node-bot',
+        kind: 'command',
+        name: 'chat',
+        body: {
+          type: 'chat',
+          args: { username, message },
+        },
+      });
 
       const ws = this.createWebSocket(this.config.agentControlWebsocketUrl);
       let settled = false;

--- a/node-bot/runtime/transportEnvelope.ts
+++ b/node-bot/runtime/transportEnvelope.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+
+import type { CommandPayload } from './types.js';
+
+export const CURRENT_TRANSPORT_VERSION = 'v1';
+
+export type EnvelopeKind = 'command' | 'event' | 'status' | 'error';
+
+export interface TransportEnvelope {
+  version: string;
+  trace_id: string;
+  run_id: string;
+  message_id: string;
+  timestamp: string;
+  source: string;
+  kind: EnvelopeKind;
+  name: string;
+  body: Record<string, unknown>;
+  auth?: Record<string, unknown> | null;
+}
+
+export function buildEnvelope(params: {
+  source: string;
+  kind: EnvelopeKind;
+  name: string;
+  body: Record<string, unknown>;
+  traceId?: string;
+  runId?: string;
+  messageId?: string;
+}): TransportEnvelope {
+  return {
+    version: CURRENT_TRANSPORT_VERSION,
+    trace_id: params.traceId ?? randomUUID(),
+    run_id: params.runId ?? randomUUID(),
+    message_id: params.messageId ?? randomUUID(),
+    timestamp: new Date().toISOString(),
+    source: params.source,
+    kind: params.kind,
+    name: params.name,
+    body: params.body,
+  };
+}
+
+export function validateEnvelope(input: unknown): TransportEnvelope | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+
+  const maybe = input as Record<string, unknown>;
+  const kind = maybe.kind;
+  if (
+    maybe.version !== CURRENT_TRANSPORT_VERSION ||
+    typeof maybe.trace_id !== 'string' ||
+    typeof maybe.run_id !== 'string' ||
+    typeof maybe.message_id !== 'string' ||
+    typeof maybe.timestamp !== 'string' ||
+    typeof maybe.source !== 'string' ||
+    (kind !== 'command' && kind !== 'event' && kind !== 'status' && kind !== 'error') ||
+    typeof maybe.name !== 'string' ||
+    !maybe.body ||
+    typeof maybe.body !== 'object'
+  ) {
+    return null;
+  }
+
+  return maybe as TransportEnvelope;
+}
+
+export function adaptLegacyCommandPayload(input: unknown): TransportEnvelope | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+
+  const payload = input as Partial<CommandPayload> & Record<string, unknown>;
+  if (typeof payload.type !== 'string' || !payload.args || typeof payload.args !== 'object') {
+    return null;
+  }
+
+  return buildEnvelope({
+    source: 'legacy-python-agent',
+    kind: 'command',
+    name: payload.type,
+    body: {
+      type: payload.type,
+      args: payload.args as Record<string, unknown>,
+      ...(payload.meta && typeof payload.meta === 'object' ? { meta: payload.meta as Record<string, unknown> } : {}),
+    },
+  });
+}

--- a/python/bridge_ws.py
+++ b/python/bridge_ws.py
@@ -3,10 +3,12 @@ import asyncio
 import json
 import logging
 import os
+from uuid import uuid4
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 import websockets
 
+from runtime.transport_envelope import make_transport_envelope
 from utils import log_structured_event, setup_logger
 
 logger = setup_logger("bridge")
@@ -46,7 +48,18 @@ class BotBridge:
         ユーザーへ再試行/断念の通知を転送できるフックを提供する。
         """
 
-        logger.info(f"WS send: {payload}")
+        trace_id = uuid4().hex
+        run_id = uuid4().hex
+        command_name = str(payload.get("type") or "unknown")
+        envelope = make_transport_envelope(
+            source="python-agent",
+            kind="command",
+            name=command_name,
+            body=payload,
+            trace_id=trace_id,
+            run_id=run_id,
+        )
+        logger.info("WS send trace_id=%s run_id=%s command=%s", trace_id, run_id, command_name)
         for attempt in range(1, self.max_retries + 1):
             stage = "connect"
             try:
@@ -55,7 +68,7 @@ class BotBridge:
                 ) as ws:
                     stage = "send"
                     await asyncio.wait_for(
-                        ws.send(json.dumps(payload, ensure_ascii=False)),
+                        ws.send(json.dumps(envelope, ensure_ascii=False)),
                         timeout=self.send_timeout,
                     )
                     stage = "recv"
@@ -76,7 +89,7 @@ class BotBridge:
                         "stage": stage,
                         "attempt": attempt,
                         "max_retries": self.max_retries,
-                        "payload": payload,
+                        "payload": envelope,
                         "error_type": error_type,
                     },
                     exc_info=error,

--- a/python/runtime/transport_envelope.py
+++ b/python/runtime/transport_envelope.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Node/Python 間 transport の共通 envelope を扱うユーティリティ。"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Dict, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+EnvelopeKind = Literal["command", "event", "status", "error"]
+CURRENT_TRANSPORT_VERSION = "v1"
+
+
+class TransportEnvelope(BaseModel):
+    """contracts/transport-envelope.schema.json と対応する envelope。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: str = Field(min_length=2)
+    trace_id: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    message_id: str = Field(min_length=1)
+    timestamp: datetime
+    source: str = Field(min_length=1)
+    kind: EnvelopeKind
+    name: str = Field(min_length=1)
+    body: Dict[str, Any]
+    auth: Dict[str, Any] | None = None
+
+
+def make_transport_envelope(
+    *,
+    source: str,
+    kind: EnvelopeKind,
+    name: str,
+    body: Dict[str, Any],
+    trace_id: str | None = None,
+    run_id: str | None = None,
+    message_id: str | None = None,
+) -> Dict[str, Any]:
+    """送信時に利用する envelope を生成して dict で返す。"""
+
+    envelope = TransportEnvelope(
+        version=CURRENT_TRANSPORT_VERSION,
+        trace_id=trace_id or uuid4().hex,
+        run_id=run_id or uuid4().hex,
+        message_id=message_id or uuid4().hex,
+        timestamp=datetime.now(UTC),
+        source=source,
+        kind=kind,
+        name=name,
+        body=body,
+    )
+    return envelope.model_dump(mode="json")
+
+
+def validate_transport_envelope(payload: Dict[str, Any]) -> TransportEnvelope:
+    """受信 payload を検証し、型安全な envelope として返す。"""
+
+    return TransportEnvelope.model_validate(payload)
+
+
+__all__ = [
+    "CURRENT_TRANSPORT_VERSION",
+    "TransportEnvelope",
+    "make_transport_envelope",
+    "validate_transport_envelope",
+]

--- a/python/runtime/websocket_server.py
+++ b/python/runtime/websocket_server.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import json
 from typing import Any, Dict
 
+from pydantic import ValidationError
+
+from runtime.transport_envelope import CURRENT_TRANSPORT_VERSION, make_transport_envelope, validate_transport_envelope
+
 from websockets import WebSocketServerProtocol
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
@@ -42,9 +46,13 @@ class AgentWebSocketServer:
             self.logger.error("invalid JSON payload=%s", raw)
             return {"ok": False, "error": "invalid json"}
 
-        payload_type = payload.get("type")
-        if payload_type == "chat":
-            args = payload.get("args") or {}
+        envelope = self._parse_envelope(payload)
+        if envelope is None:
+            return {"ok": False, "error": "invalid envelope"}
+
+        body = envelope.body
+        if envelope.kind == "command" and envelope.name == "chat":
+            args = body.get("args") or {}
             username = str(args.get("username", "")).strip() or "Player"
             message = str(args.get("message", "")).strip()
 
@@ -53,12 +61,42 @@ class AgentWebSocketServer:
                 return {"ok": False, "error": "empty message"}
 
             await self.orchestrator.enqueue_chat(username, message)
-            return {"ok": True}
+            return self._ok_response(envelope)
 
-        if payload_type == "agentEvent":
-            args = payload.get("args") or {}
+        if envelope.kind == "event" and envelope.name == "agentEvent":
+            args = body.get("args") or {}
             await self.orchestrator.handle_agent_event(args)
-            return {"ok": True}
+            return self._ok_response(envelope)
 
-        self.logger.error("unsupported payload type=%s", payload_type)
+        self.logger.error("unsupported envelope kind=%s name=%s", envelope.kind, envelope.name)
         return {"ok": False, "error": "unsupported type"}
+
+    def _parse_envelope(self, payload: Dict[str, Any]):
+        try:
+            envelope = validate_transport_envelope(payload)
+            if envelope.version != CURRENT_TRANSPORT_VERSION:
+                self.logger.error("unsupported envelope version=%s", envelope.version)
+                return None
+            return envelope
+        except ValidationError:
+            legacy_type = payload.get("type")
+            if isinstance(legacy_type, str) and isinstance(payload.get("args"), dict):
+                self.logger.warning("legacy payload detected type=%s; wrap into envelope", legacy_type)
+                legacy_kind = "event" if legacy_type == "agentEvent" else "command"
+                wrapped = make_transport_envelope(
+                    source="legacy-node-bot",
+                    kind=legacy_kind,
+                    name=legacy_type,
+                    body={"type": legacy_type, "args": payload.get("args")},
+                )
+                return validate_transport_envelope(wrapped)
+            self.logger.exception("invalid transport envelope payload=%s", payload)
+            return None
+
+    def _ok_response(self, envelope) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "trace_id": envelope.trace_id,
+            "run_id": envelope.run_id,
+            "message_id": envelope.message_id,
+        }


### PR DESCRIPTION
### Motivation
- Node と Python 間の ad-hoc ペイロードを廃し、相関 ID を含む versioned envelope を正本にして通信契約を明確にするため。 
- 既存の legacy `{type,args}` 互換レイヤを一箇所に集約し、段階的移行を可能にするため。 

### Description
- 送受信用の仕様ファイル `contracts/transport-envelope.schema.json` を追加し、`version/trace_id/run_id/message_id/timestamp/source/kind/name/body/auth` を定義した。 
- Python 側に `python/runtime/transport_envelope.py` を追加し、`bridge_ws.py` の送信を envelope 化、`python/runtime/websocket_server.py` の受信でバリデーションと legacy adapter を導入した（不正/バージョン不一致は明示的に失敗）。 
- Node 側に `node-bot/runtime/transportEnvelope.ts` を追加し、`node-bot/runtime/server.ts` の受信で envelope 検証を行うよう変更し、`node-bot/runtime/services/chatBridge.ts` と `node-bot/runtime/agentBridge.ts` の送信を envelope 化した。 
- ドキュメントを更新して移行方針を明記（`README.md`, `docs/refactor/phase3.md` に Slice 2 完了報告を追加）。 

### Testing
- `bash scripts/setup-python-env.sh` を実行して Python 開発環境のセットアップに成功した。 
- `. .venv/bin/activate && python -m pytest tests/test_actions_payloads.py` が成功（10 tests passed）。 
- `. .venv/bin/activate && python -m pytest tests/test_bridge_ws.py` が成功（2 tests passed）。 
- Python 実装ファイルは `python -m compileall` によりコンパイル確認済み。 
- Node 側の `cd node-bot && npm ci` はローカル環境の Node が v20.19.6 で package が `node>=22` を要求するため失敗し、`npm test` / `npm run build` は依存未導入で実行できなかった（環境依存のため追って CI / Docker で検証を推奨）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c385cc58832cbd59876382c71f67)