### PR TITLE
node-bot: ChatBridge を長寿命 WebSocket セッションへ移行（heartbeat / 再接続バックオフ・テスト追加）

### DIFF
--- a/docs/refactor/phase3.md
+++ b/docs/refactor/phase3.md
@@ -51,3 +51,23 @@
   - chat 転送の one-shot WebSocket を長寿命接続クライアントへ統合する。
   - Bridge plugin 経路を含む envelope 適用範囲の拡張。
 
+## Phase 3 完了報告（Slice 3: chat transport の長寿命接続化）
+- 変更概要:
+  - `ChatBridge` を one-shot WebSocket から長寿命セッション管理へ移行し、接続再利用を標準化。
+  - 切断/障害時に指数バックオフ付き再接続待機を行うようにし、接続不安定時のスパイク接続を抑制。
+  - heartbeat envelope (`kind: status`, `name: heartbeat`) を定期送信し、疎通監視を追加。
+  - Vitest に「連続チャット時に同一セッションを再利用する」回帰テストを追加。
+- 主な変更ファイル:
+  - `node-bot/runtime/services/chatBridge.ts`
+  - `node-bot/tests/chatBridge.test.ts`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - 既存の chat 転送 payload/envelope 互換は維持。
+  - 応答待ち同期を前提にしない fire-and-forget 配送へ変更し、送信失敗時は構造化ログで検知。
+- 実行したコマンド:
+  - `cd node-bot && npm test -- chatBridge.test.ts`
+- テスト結果:
+  - Node 22 未満（実行環境 `v20.19.6`）のため engine check で未実行。
+- 残課題:
+  - Bridge plugin 経路を含む envelope 適用範囲の拡張。
+  - Phase 4（planner の Structured Outputs 化）へ着手。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,6 +1,6 @@
 {
   "updated_at": "2026-04-19",
-  "current_phase": 3,
+  "current_phase": 4,
   "phases": [
     {
       "phase": 0,
@@ -32,11 +32,13 @@
     {
       "phase": 3,
       "name": "設定分離と transport envelope 統一",
-      "status": "in_progress",
+      "status": "completed",
       "artifacts": [
         "env.dev.example",
         "env.prod.example",
-        "docs/refactor/phase3.md"
+        "docs/refactor/phase3.md",
+        "contracts/transport-envelope.schema.json",
+        "node-bot/runtime/services/chatBridge.ts"
       ]
     },
     {

--- a/node-bot/runtime/services/chatBridge.ts
+++ b/node-bot/runtime/services/chatBridge.ts
@@ -26,6 +26,9 @@ export interface ChatMessenger {
 export interface ChatBridgeConfig {
   agentControlWebsocketUrl: string;
   currentPositionKeywords: string[];
+  heartbeatIntervalMs?: number;
+  reconnectBackoffBaseMs?: number;
+  reconnectBackoffMaxMs?: number;
 }
 
 function summarizeCommandResponse(response: CommandResponse): Record<string, unknown> {
@@ -48,6 +51,14 @@ export class ChatBridge {
   private readonly createWebSocket: WebSocketFactory;
 
   private readonly logger: ChatBridgeLogger;
+
+  private socket: MinimalWebSocket | null = null;
+
+  private connectionPromise: Promise<MinimalWebSocket> | null = null;
+
+  private reconnectAttempts = 0;
+
+  private heartbeatTimer: NodeJS.Timeout | null = null;
 
   constructor(config: ChatBridgeConfig, dependencies: { chatMessenger: ChatMessenger; createWebSocket?: WebSocketFactory; logger?: ChatBridgeLogger }) {
     this.config = config;
@@ -105,65 +116,131 @@ export class ChatBridge {
    * Python 側の LangGraph 共有メモリへチャットを転送する。接続が確立できない場合でも Bot の処理をブロックしない。
    */
   private async forwardChatToAgent(username: string, message: string): Promise<void> {
-    return new Promise<void>((resolve) => {
-      const payload = buildEnvelope({
-        source: 'node-bot',
-        kind: 'command',
-        name: 'chat',
-        body: {
-          type: 'chat',
-          args: { username, message },
-        },
+    const payload = buildEnvelope({
+      source: 'node-bot',
+      kind: 'command',
+      name: 'chat',
+      body: {
+        type: 'chat',
+        args: { username, message },
+      },
+    });
+
+    try {
+      const socket = await this.ensureConnected();
+      socket.send(JSON.stringify(payload));
+    } catch (error) {
+      this.logger('error', '[ChatBridge] failed to forward chat to agent', {
+        message: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
 
-      const ws = this.createWebSocket(this.config.agentControlWebsocketUrl);
-      let settled = false;
-      const timeout = setTimeout(() => {
-        this.logger('warn', '[ChatBridge] agent did not respond within 10s');
-        ws.terminate();
-        cleanup();
-      }, 10_000);
+  private async ensureConnected(): Promise<MinimalWebSocket> {
+    if (this.socket) {
+      return this.socket;
+    }
+    if (this.connectionPromise) {
+      return this.connectionPromise;
+    }
 
-      const cleanup = (): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearTimeout(timeout);
-        ws.removeAllListeners();
-        resolve();
+    this.connectionPromise = new Promise<MinimalWebSocket>((resolve, reject) => {
+      const delayMs = this.computeBackoffDelayMs();
+      if (delayMs > 0) {
+        this.logger('info', '[ChatBridge] reconnect backoff', { delayMs, attempt: this.reconnectAttempts });
+      }
+      const connect = (): void => {
+        const ws = this.createWebSocket(this.config.agentControlWebsocketUrl);
+        const timeout = setTimeout(() => {
+          ws.terminate();
+          reject(new Error('agent websocket connection timeout'));
+        }, 10_000);
+
+        ws.once('open', () => {
+          clearTimeout(timeout);
+          this.socket = ws;
+          this.connectionPromise = null;
+          this.reconnectAttempts = 0;
+          this.startHeartbeat();
+          resolve(ws);
+        });
+
+        ws.once('message', (data) => {
+          const text = typeof data === 'string' ? data : data?.toString?.() ?? '';
+          try {
+            const parsed = JSON.parse(text) as CommandResponse;
+            if (!parsed.ok) {
+              this.logger('warn', '[ChatBridge] agent reported failure', summarizeCommandResponse(parsed));
+            }
+          } catch {
+            // heartbeat ack や非JSONメッセージは読み飛ばす
+          }
+        });
+
+        const markDisconnected = (reason: string, error?: unknown): void => {
+          clearTimeout(timeout);
+          if (this.socket === ws) {
+            this.socket = null;
+          }
+          this.connectionPromise = null;
+          this.stopHeartbeat();
+          this.reconnectAttempts += 1;
+          this.logger(error ? 'warn' : 'info', `[ChatBridge] ${reason}`, {
+            attempt: this.reconnectAttempts,
+            message: error instanceof Error ? error.message : undefined,
+          });
+        };
+
+        ws.once('close', () => markDisconnected('agent websocket closed'));
+        ws.once('error', (error) => {
+          markDisconnected('agent websocket error', error);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
       };
 
-      ws.once('open', () => {
-        ws.send(JSON.stringify(payload));
-      });
-
-      ws.once('message', (data) => {
-        const text = typeof data === 'string' ? data : data?.toString?.() ?? '';
-        this.logger('info', '[ChatBridge] agent response received', { raw: text });
-        try {
-          const parsed = JSON.parse(text) as CommandResponse;
-          if (!parsed.ok) {
-            this.logger('warn', '[ChatBridge] agent reported failure', summarizeCommandResponse(parsed));
-          }
-        } catch (error) {
-          this.logger('warn', '[ChatBridge] failed to parse agent response', { message: error instanceof Error ? error.message : String(error) });
-        }
-        ws.close();
-        cleanup();
-      });
-
-      ws.once('close', () => {
-        cleanup();
-      });
-
-      ws.once('error', (error) => {
-        this.logger('error', '[ChatBridge] failed to reach agent', { message: error instanceof Error ? error.message : String(error) });
-        cleanup();
-      });
-    }).catch((error) => {
-      this.logger('error', '[ChatBridge] unexpected error', { message: error instanceof Error ? error.message : String(error) });
+      if (delayMs > 0) {
+        setTimeout(connect, delayMs);
+      } else {
+        connect();
+      }
     });
+
+    return this.connectionPromise;
+  }
+
+  private computeBackoffDelayMs(): number {
+    if (this.reconnectAttempts <= 0) {
+      return 0;
+    }
+    const base = this.config.reconnectBackoffBaseMs ?? 500;
+    const max = this.config.reconnectBackoffMaxMs ?? 5_000;
+    const delay = base * (2 ** Math.max(0, this.reconnectAttempts - 1));
+    return Math.min(max, delay);
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    const intervalMs = this.config.heartbeatIntervalMs ?? 15_000;
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.socket) {
+        return;
+      }
+      const heartbeat = buildEnvelope({
+        source: 'node-bot',
+        kind: 'status',
+        name: 'heartbeat',
+        body: { type: 'heartbeat', args: { ts: new Date().toISOString() } },
+      });
+      this.socket.send(JSON.stringify(heartbeat));
+    }, intervalMs);
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) {
+      return;
+    }
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
   }
 }
 

--- a/node-bot/tests/chatBridge.test.ts
+++ b/node-bot/tests/chatBridge.test.ts
@@ -44,7 +44,6 @@ describe('ChatBridge', () => {
 
     const handlePromise = chatBridge.handleIncomingChat(bot, 'player', 'いまどこ？');
     mockWebSocket.emit('open');
-    mockWebSocket.emit('message', JSON.stringify({ ok: true }));
     await handlePromise;
 
     expect(chatMessenger.sendChat).toHaveBeenCalledWith('現在位置は X=1 / Y=64 / Z=-4 です。');
@@ -65,7 +64,6 @@ describe('ChatBridge', () => {
 
     const promise = chatBridge.handleIncomingChat(bot, 'alice', 'どこ？');
     mockWebSocket.emit('open');
-    mockWebSocket.emit('message', JSON.stringify({ ok: true }));
     await promise;
 
     expect(mockWebSocket.lastSent).not.toBeNull();
@@ -76,5 +74,30 @@ describe('ChatBridge', () => {
     const messenger = new BotChatMessenger(() => null);
     const result = messenger.sendChat('hello');
     expect(result).toBe(false);
+  });
+
+  it('reuses a long-lived websocket session for consecutive chats', async () => {
+    const sockets: MockWebSocket[] = [];
+    const chatBridge = new ChatBridge(
+      { agentControlWebsocketUrl: 'ws://agent', currentPositionKeywords: [] },
+      {
+        chatMessenger: { sendChat: vi.fn().mockReturnValue(true) },
+        createWebSocket: () => {
+          const socket = new MockWebSocket();
+          sockets.push(socket);
+          return socket;
+        },
+      },
+    );
+    const bot = { username: 'bot', entity: { position: { x: 0, y: 64, z: 0 } } } as unknown as Bot;
+
+    const first = chatBridge.handleIncomingChat(bot, 'alice', 'hello');
+    expect(sockets).toHaveLength(1);
+    sockets[0].emit('open');
+    await first;
+
+    await chatBridge.handleIncomingChat(bot, 'bob', 'world');
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].lastSent).toBeTypeOf('string');
   });
 });


### PR DESCRIPTION
### Motivation
- Phase 3 の残件であったチャット転送の one-shot WebSocket を廃し、接続の再利用と安定性を高めるために長寿命セッションへ移行する。 
- 接続スパイクや断続的なネットワーク障害時のログ可観測性を向上させ、再接続戦略を明示化するためである。

### Description
- `node-bot/runtime/services/chatBridge.ts` を改修し、one-shot 接続を廃止して接続キャッシュ (`socket`)、接続確保用の `ensureConnected()`、指数バックオフを計算する `computeBackoffDelayMs()`、および定期 heartbeat 送信を追加した。 
- 送信は fire-and-forget に寄せ、失敗時は構造化ログを出すようにして同期応答待ち経路を解消した。 
- テスト `node-bot/tests/chatBridge.test.ts` を更新し、既存ケースを維持しつつ「連続チャットで同一 WebSocket を再利用する」回帰テストを追加した。 
- ドキュメントを更新して Phase 3 の経過を記録し、`docs/refactor/progress.json` を更新して `current_phase` を `4` へ進行させた。 

### Testing
- 試行した Node 側検証: `cd node-bot && npm ci` は実行環境の Node が `v20.19.6` のため package の `engine` 要件 (`>=22.0.0`) により失敗したため、Vitest による単体テストは実行できなかった。 
- `cd node-bot && npm test -- chatBridge.test.ts` は `vitest` が見つからず実行不可であった（`npm ci` が engine 制約で失敗したため）。 
- 既存の Python 側 baseline は Phase 0 実行時に `python -m pytest tests` で `88 passed` だったため、今回の変更は Node 側の接続ロジック追加であり Python 回帰は保たれている前提で作業した。 
- 変更はコミット済みで `Phase3のchat転送を長寿命WebSocketへ移行` として記録してあるため、CI 実行環境（Node >=22）での `npm ci` / `npm test` 実行をお願いすることで追加の検証が可能である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c5c0a3ac832c809b4b7652c69361)