### PR TITLE
Phase4: planner の schema-first 移行を開始

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -1,0 +1,23 @@
+# Phase 4 進捗報告
+
+## Phase 4 完了報告
+- 変更概要:
+  - planner の Responses payload 生成に `json_schema` 指定を導入し、`PlanOut` / `BarrierNotification` を schema-first で要求するように更新。
+  - parse 経路を「まず schema を直接検証」へ変更し、旧来の `_normalize_plan_json()` は legacy fallback として限定利用に縮小。
+  - payload の契約退行を防ぐ unit test（schema 指定時 / 非指定時）を追加。
+- 主な変更ファイル:
+  - `python/planner/__init__.py`
+  - `python/planner/graph.py`
+  - `tests/test_planner_responses_payload.py`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - planner 主経路は schema-first へ移行。
+  - 非構造化 JSON 揺れは一時的に normalize fallback で吸収しつつ、warning ログで可視化。
+- 実行したコマンド:
+  - `python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（2 passed）。
+- 残課題:
+  - planner prompt から出力フォーマット強制文言をさらに削減し、計画品質重視へ寄せる。
+  - `_normalize_plan_json()` を旧 state 移行用途まで段階的に縮小する。
+  - refusal / 空応答 / 不完全応答の回帰テストを拡充する。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -44,7 +44,13 @@
     {
       "phase": 4,
       "name": "planner を Structured Outputs 化",
-      "status": "pending"
+      "status": "in_progress",
+      "artifacts": [
+        "docs/refactor/phase4.md",
+        "python/planner/__init__.py",
+        "python/planner/graph.py",
+        "tests/test_planner_responses_payload.py"
+      ]
     },
     {
       "phase": 5,

--- a/python/planner/__init__.py
+++ b/python/planner/__init__.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import openai
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Type
 
 from langgraph.graph.state import CompiledStateGraph
+from pydantic import BaseModel
 
 from llm.client import (
     AsyncOpenAI,
@@ -62,13 +63,30 @@ _ASYNC_CLIENT_FACTORY = _default_async_client_factory
 _PLAN_GRAPH: Optional[CompiledStateGraph] = None
 
 
-def _build_responses_payload(system_prompt: str, user_prompt: str, config: PlannerConfig) -> Dict[str, Any]:
+def _build_responses_payload(
+    system_prompt: str,
+    user_prompt: str,
+    config: PlannerConfig,
+    *,
+    schema_model: Optional[Type[BaseModel]] = None,
+    schema_name: Optional[str] = None,
+) -> Dict[str, Any]:
     """Responses API 呼び出しに共通するペイロードを一元生成する。"""
+
+    if schema_model is None:
+        text_format: Dict[str, Any] = {"type": "json_object"}
+    else:
+        text_format = {
+            "type": "json_schema",
+            "name": schema_name or schema_model.__name__,
+            "schema": schema_model.model_json_schema(),
+            "strict": True,
+        }
 
     payload: Dict[str, Any] = {
         "model": config.model,
         "input": _build_responses_input(system_prompt, user_prompt),
-        "text": {"format": {"type": "json_object"}},
+        "text": {"format": text_format},
     }
 
     temperature = resolve_request_temperature(config)
@@ -93,7 +111,13 @@ def _get_plan_graph() -> CompiledStateGraph:
             _PLANNER_CONFIG,
             priority_manager=_PRIORITY_MANAGER,
             async_client_factory=_ASYNC_CLIENT_FACTORY,
-            payload_builder=lambda system, user: _build_responses_payload(system, user, _PLANNER_CONFIG),
+            payload_builder=lambda system, user: _build_responses_payload(
+                system,
+                user,
+                _PLANNER_CONFIG,
+                schema_model=PlanOut,
+                schema_name="plan_out",
+            ),
         )
     return _PLAN_GRAPH
 
@@ -159,7 +183,13 @@ async def compose_barrier_notification(
     prompt = build_barrier_prompt(step, reason, context)
     logger.info(f"Barrier prompt: {prompt}")
 
-    request_payload = _build_responses_payload(BARRIER_SYSTEM, prompt, _PLANNER_CONFIG)
+    request_payload = _build_responses_payload(
+        BARRIER_SYSTEM,
+        prompt,
+        _PLANNER_CONFIG,
+        schema_model=BarrierNotification,
+        schema_name="barrier_notification",
+    )
 
     try:
         resp = await asyncio.wait_for(

--- a/python/planner/graph.py
+++ b/python/planner/graph.py
@@ -300,23 +300,30 @@ def build_plan_graph(
             return result
 
         raw_content = state.get("content") or ""
-        normalized_content = _normalize_plan_json(raw_content)
         try:
-            plan_data = PlanOut.model_validate_json(normalized_content)
-        except Exception as exc:
-            logger.exception("plan graph failed to parse JSON plan")
-            priority = await manager.mark_failure()
-            result = {"parse_error": str(exc), "priority": priority}
-            result.update(
-                record_structured_step(
-                    state,
-                    step_label="parse_plan",
-                    inputs={"content_preview": raw_content[:120]},
-                    outputs={"priority": priority},
-                    error=str(exc),
+            plan_data = PlanOut.model_validate_json(raw_content)
+        except Exception as primary_exc:
+            normalized_content = _normalize_plan_json(raw_content)
+            try:
+                plan_data = PlanOut.model_validate_json(normalized_content)
+                logger.warning(
+                    "plan graph used legacy JSON normalize fallback: %s",
+                    primary_exc.__class__.__name__,
                 )
-            )
-            return result
+            except Exception as secondary_exc:
+                logger.exception("plan graph failed to parse JSON plan")
+                priority = await manager.mark_failure()
+                result = {"parse_error": str(secondary_exc), "priority": priority}
+                result.update(
+                    record_structured_step(
+                        state,
+                        step_label="parse_plan",
+                        inputs={"content_preview": raw_content[:120]},
+                        outputs={"priority": priority},
+                        error=str(secondary_exc),
+                    )
+                )
+                return result
 
         # LLM 出力が空配列の場合は実行フェーズで詰まるため、ここでチャット確認に切り替える。
         if not plan_data.plan:

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -1,0 +1,36 @@
+from planner import _build_responses_payload
+from planner.models import PlanOut
+from planner_config import PlannerConfig
+
+
+def _make_config() -> PlannerConfig:
+    return PlannerConfig(
+        model="gpt-5-mini",
+        default_temperature=0.3,
+        temperature_locked_models={"gpt-5-mini"},
+        allowed_verbosity_levels={"low", "medium", "high"},
+        allowed_reasoning_effort={"low", "medium", "high"},
+        llm_timeout_seconds=30.0,
+    )
+
+
+def test_build_responses_payload_uses_json_schema_for_planout() -> None:
+    payload = _build_responses_payload(
+        "system",
+        "user",
+        _make_config(),
+        schema_model=PlanOut,
+        schema_name="plan_out",
+    )
+
+    fmt = payload["text"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["name"] == "plan_out"
+    assert fmt["strict"] is True
+    assert "properties" in fmt["schema"]
+    assert "plan" in fmt["schema"]["properties"]
+
+
+def test_build_responses_payload_falls_back_to_json_object_without_schema() -> None:
+    payload = _build_responses_payload("system", "user", _make_config())
+    assert payload["text"]["format"] == {"type": "json_object"}


### PR DESCRIPTION
### Motivation
- Planner の出力をプロンプト強制から schema-first へ移し、LLM 出力の正本を Pydantic スキーマに移行するため。
- 既存の normalize 修理ロジックを主経路から外し、段階的かつ可視化された後方互換を保ちつつ移行を進めるため。

### Description
- `python/planner/__init__.py` に `_build_responses_payload(..., schema_model, schema_name)` を追加し、Responses API ペイロードで `json_schema` 指定が可能になりました。
- デフォルトの planner 呼び出しでは `PlanOut` スキーマを `schema_model` に渡し、障壁通知では `BarrierNotification` スキーマを指定するよう変更しました。
- `python/planner/graph.py` の `parse_plan` ロジックを修正し、まず生の LLM 出力を `PlanOut.model_validate_json(raw_content)` で検証し、失敗時のみ `_normalize_plan_json()` を legacy フォールバックとして試す段階移行に変更しました（フォールバック時は warning を出力）。
- schema 指定時/非指定時の挙動を固定するユニットテスト `tests/test_planner_responses_payload.py` を追加しました。
- 進捗管理を更新して `docs/refactor/progress.json` を `in_progress` にし、Phase4 の進捗レポート `docs/refactor/phase4.md` を追加しました。

### Testing
- 単体テスト実行: `PYTHONPATH=/workspace/mc-bot-egent-practice-1:/workspace/mc-bot-egent-practice-1/python python -m pytest tests/test_planner_responses_payload.py` を実行し `2 passed` となり成功しました.
- 事前に通常実行した `python -m pytest tests/test_planner_responses_payload.py` は `ModuleNotFoundError: No module named 'planner'` のため失敗し、その後 `PYTHONPATH` を指定して再実行して成功しています.
- 変更対象ファイル（主なもの）: `python/planner/__init__.py`, `python/planner/graph.py`, `tests/test_planner_responses_payload.py`, `docs/refactor/progress.json`, `docs/refactor/phase4.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c8eec190832c8e85e7d4e2d3befc)