### PR TITLE
Phase4: plannerの制御失敗ケース回帰テストを追加

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -21,3 +21,19 @@
   - planner prompt から出力フォーマット強制文言をさらに削減し、計画品質重視へ寄せる。
   - `_normalize_plan_json()` を旧 state 移行用途まで段階的に縮小する。
   - refusal / 空応答 / 不完全応答の回帰テストを拡充する。
+
+## 追加スライス (2026-04-19)
+- 変更概要:
+  - planner の parse 経路に対する回帰テストを拡張し、`plan=[]` 応答と不正 JSON 応答の制御された失敗を固定化。
+  - `build_plan_graph` をテストダブルで起動し、Responses API の実ネットワーク呼び出しなしで parse/fallback の契約を検証。
+- 主な変更ファイル:
+  - `tests/test_planner_responses_payload.py`
+- 互換性影響:
+  - 実装変更なし（テスト追加のみ）。
+  - 空手順時に `next_action=chat` / `clarification_needed=data_gap` を維持することを明示的に保証。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（4 passed）。
+- 残課題:
+  - refusal/空文字応答/必須キー欠落のケースをさらに網羅し、legacy normalize 依存領域を縮小する。

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -1,6 +1,9 @@
 from planner import _build_responses_payload
+from planner.graph import build_plan_graph
 from planner.models import PlanOut
+from planner.priority import PlanPriorityManager
 from planner_config import PlannerConfig
+import pytest
 
 
 def _make_config() -> PlannerConfig:
@@ -34,3 +37,50 @@ def test_build_responses_payload_uses_json_schema_for_planout() -> None:
 def test_build_responses_payload_falls_back_to_json_object_without_schema() -> None:
     payload = _build_responses_payload("system", "user", _make_config())
     assert payload["text"]["format"] == {"type": "json_object"}
+
+
+class _FakeResponses:
+    def __init__(self, output_text: str) -> None:
+        self._output_text = output_text
+
+    async def create(self, **_: object) -> object:
+        return type("FakeResponse", (), {"output_text": self._output_text, "output": []})()
+
+
+class _FakeAsyncClient:
+    def __init__(self, output_text: str) -> None:
+        self.responses = _FakeResponses(output_text)
+
+
+async def _invoke_graph_with_output(output_text: str) -> PlanOut:
+    config = _make_config()
+    graph = build_plan_graph(
+        config,
+        priority_manager=PlanPriorityManager(config),
+        async_client_factory=lambda: _FakeAsyncClient(output_text),
+        payload_builder=lambda system_prompt, user_prompt: {
+            "model": config.model,
+            "input": [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
+            "text": {"format": {"type": "json_schema"}},
+        },
+    )
+
+    result = await graph.ainvoke({"user_msg": "test", "context": {}, "structured_events": []})
+    assert isinstance(result.get("plan_out"), PlanOut)
+    return result["plan_out"]
+
+
+@pytest.mark.anyio
+async def test_plan_graph_handles_empty_plan_as_controlled_chat_fallback() -> None:
+    plan_out = await _invoke_graph_with_output('{"plan":[],"resp":"", "intent":"move"}')
+    assert plan_out.next_action == "chat"
+    assert plan_out.blocking is True
+    assert plan_out.clarification_needed == "data_gap"
+    assert any(item.get("label") == "plan_empty" for item in plan_out.backlog)
+
+
+@pytest.mark.anyio
+async def test_plan_graph_returns_safe_fallback_on_invalid_json() -> None:
+    plan_out = await _invoke_graph_with_output("not-json")
+    assert plan_out.plan == []
+    assert plan_out.resp == "了解しました。"


### PR DESCRIPTION
### Motivation
- planner の parse/復元経路で発生しやすい制御失敗（空の `plan` や不正 JSON 応答）を契約として固定化し、後続の schema-first 移行で壊れないようにする。 
- ネットワークを伴う Responses API 呼び出しに依存せずに LangGraph の parse/fallback 挙動を検証できるようにする。 

### Description
- `tests/test_planner_responses_payload.py` にテストダブル（fake Responses client）を用いて `build_plan_graph` を起動する回帰テストを追加し、空配列応答時の `next_action=chat` / `clarification_needed=data_gap` への遷移を検証するテストを追加しました。 
- 同ファイルに不正 JSON 応答時の安全なフォールバック（`plan=[]` と `resp=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4cde402d4832c81363aeeaf0bef9a)