### PR TITLE
planner: Responses の refusal を制御された chat フォールバックとして扱う

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -55,3 +55,23 @@
 - 残課題:
   - Responses API の refusal シグナル（`response.output` 内の refusal content）に対するハンドリングと回帰テストを追加する。
   - `_normalize_plan_json()` の適用条件をさらに絞り、legacy state 移行用途へ段階的に限定する。
+
+## 追加スライス (2026-04-19, 3)
+- 変更概要:
+  - planner の `call_llm` で Responses API の refusal を検知し、空文字応答時でも拒否メッセージを `PlanOut` の制御された chat フォールバックとして返すように更新。
+  - refusal 検知ロジックを `planner/prompts.py` に追加し、`message.content[].type == refusal` と `item.type == refusal` の双方を安全に抽出可能にした。
+  - 回帰テストを追加し、refusal 発生時に `next_action=chat`・`clarification_needed=confirmation`・`plan_refusal` backlog が維持されることを固定化。
+- 主な変更ファイル:
+  - `python/planner/prompts.py`
+  - `python/planner/graph.py`
+  - `tests/test_planner_responses_payload.py`
+- 互換性影響:
+  - 正常系の schema-first 経路は変更なし。
+  - refusal シグナル時は汎用 `"了解しました。"` ではなく、モデルが返した確認メッセージを優先して返すように改善。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（7 passed）。
+  - OpenTelemetry exporter が `localhost:4318` 未起動のため warning ログが出るが、テスト自体は成功。
+- 残課題:
+  - `_normalize_plan_json()` の適用条件をさらに絞り、legacy state 移行用途へ段階的に限定する。

--- a/python/planner/graph.py
+++ b/python/planner/graph.py
@@ -35,6 +35,7 @@ from .prompts import (
     build_pre_action_review_prompt,
     build_responses_input,
     build_user_prompt,
+    extract_refusal_text,
     extract_output_text,
 )
 from .state import UnifiedPlanState, record_recovery_hints, record_structured_step, logger
@@ -221,11 +222,16 @@ def build_plan_graph(
             attributes={"llm.model": config.model},
         ) as span:
 
-            async def _build_failure_payload(reason: str, *, log_as_warning: bool) -> Dict[str, Any]:
+            async def _build_failure_payload(
+                reason: str,
+                *,
+                log_as_warning: bool,
+                fallback_plan: PlanOut | None = None,
+            ) -> Dict[str, Any]:
                 """例外発生時に優先度降格とフォールバックプランを組み立てる。"""
 
                 priority = await manager.mark_failure()
-                fallback = PlanOut(plan=[], resp="了解しました。")
+                fallback = fallback_plan or PlanOut(plan=[], resp="了解しました。")
                 if log_as_warning:
                     logger.warning("plan graph detected LLM timeout: %s", reason)
                 else:
@@ -267,6 +273,26 @@ def build_plan_graph(
                 return await _build_failure_payload(str(exc), log_as_warning=False)
 
             content = extract_output_text(resp)
+            refusal_text = extract_refusal_text(resp)
+            if not content and refusal_text:
+                return await _build_failure_payload(
+                    f"response refusal: {refusal_text[:120]}",
+                    log_as_warning=True,
+                    fallback_plan=PlanOut(
+                        plan=[],
+                        resp=refusal_text,
+                        blocking=True,
+                        next_action="chat",
+                        clarification_needed="confirmation",
+                        backlog=[
+                            {
+                                "type": "plan",
+                                "summary": "モデルが追加確認を要求しました",
+                                "label": "plan_refusal",
+                            }
+                        ],
+                    ),
+                )
             logger.info("LLM raw: %s", content)
             payload = {"response": resp, "content": content}
             payload.update(

--- a/python/planner/prompts.py
+++ b/python/planner/prompts.py
@@ -123,6 +123,27 @@ def extract_output_text(response: Response) -> str:
     return ""
 
 
+def extract_refusal_text(response: Response) -> str:
+    """Responses API の拒否メッセージを安全に抽出する。"""
+
+    for item in response.output or []:
+        item_type = getattr(item, "type", None)
+        if item_type == "refusal":
+            candidate = getattr(item, "refusal", "") or getattr(item, "text", "")
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+
+        if item_type == "message":
+            for content in getattr(item, "content", []):
+                content_type = getattr(content, "type", None)
+                if content_type == "refusal":
+                    candidate = getattr(content, "refusal", "") or getattr(content, "text", "")
+                    if isinstance(candidate, str) and candidate.strip():
+                        return candidate.strip()
+
+    return ""
+
+
 __all__ = [
     "BARRIER_SYSTEM",
     "SOCRATIC_REVIEW_SYSTEM",
@@ -131,5 +152,6 @@ __all__ = [
     "build_pre_action_review_prompt",
     "build_responses_input",
     "build_user_prompt",
+    "extract_refusal_text",
     "extract_output_text",
 ]

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -40,24 +40,25 @@ def test_build_responses_payload_falls_back_to_json_object_without_schema() -> N
 
 
 class _FakeResponses:
-    def __init__(self, output_text: str) -> None:
+    def __init__(self, output_text: str, output: list[object] | None = None) -> None:
         self._output_text = output_text
+        self._output = output or []
 
     async def create(self, **_: object) -> object:
-        return type("FakeResponse", (), {"output_text": self._output_text, "output": []})()
+        return type("FakeResponse", (), {"output_text": self._output_text, "output": self._output})()
 
 
 class _FakeAsyncClient:
-    def __init__(self, output_text: str) -> None:
-        self.responses = _FakeResponses(output_text)
+    def __init__(self, output_text: str, output: list[object] | None = None) -> None:
+        self.responses = _FakeResponses(output_text, output)
 
 
-async def _invoke_graph_with_output(output_text: str) -> PlanOut:
+async def _invoke_graph_with_output(output_text: str, output: list[object] | None = None) -> PlanOut:
     config = _make_config()
     graph = build_plan_graph(
         config,
         priority_manager=PlanPriorityManager(config),
-        async_client_factory=lambda: _FakeAsyncClient(output_text),
+        async_client_factory=lambda: _FakeAsyncClient(output_text, output),
         payload_builder=lambda system_prompt, user_prompt: {
             "model": config.model,
             "input": [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
@@ -100,3 +101,16 @@ async def test_plan_graph_returns_safe_fallback_when_required_fields_are_missing
     assert plan_out.resp == "手順が生成できませんでした。もう少し具体的に指示してください。"
     assert plan_out.next_action == "chat"
     assert plan_out.clarification_needed == "data_gap"
+
+
+@pytest.mark.anyio
+async def test_plan_graph_uses_refusal_message_as_controlled_chat_fallback() -> None:
+    refusal_content = type("FakeRefusalContent", (), {"type": "refusal", "refusal": "危険な操作のため確認が必要です"})()
+    refusal_message = type("FakeMessage", (), {"type": "message", "content": [refusal_content]})()
+    plan_out = await _invoke_graph_with_output("", output=[refusal_message])
+    assert plan_out.plan == []
+    assert plan_out.resp == "危険な操作のため確認が必要です"
+    assert plan_out.next_action == "chat"
+    assert plan_out.blocking is True
+    assert plan_out.clarification_needed == "confirmation"
+    assert any(item.get("label") == "plan_refusal" for item in plan_out.backlog)


### PR DESCRIPTION
### Motivation
- Responses API が返す拒否（refusal）シグナルを取りこぼさず、安全かつ説明責任のあるフォールバック経路へ導くための対応を追加しました。
- 空の出力本文に対して汎用メッセージで埋める代わりに、モデルが提示した確認メッセージを優先してプレイヤー確認フローへ遷移させることで誤実行リスクを下げます。

### Description
- `python/planner/prompts.py` に `extract_refusal_text()` を追加し、`item.type == "refusal"` と `message.content[].type == "refusal"` の両形式から拒否メッセージを安全に抽出するようにしました。 
- `python/planner/graph.py` の `call_llm` で「本文が空かつ refusal が存在する」ケースを検知し、`PlanOut` の制御された chat フォールバック（`blocking=true`、`next_action='chat'`、`clarification_needed='confirmation'`、`plan_refusal` backlog）を返すようにしました。併せて失敗ペイロード生成関数を `fallback_plan` 注入に対応させました。 
- テスト `tests/test_planner_responses_payload.py` を拡張し、refusal を含むメッセージを模したスタブで期待されるフォールバック状態が返ることを固定化しました。 
- ドキュメント `docs/refactor/phase4.md` に今回のスライス内容と結果・残課題を追記しました。 

### Testing
- 実行したコマンド: `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py` が成功し、`7 passed` でした。 
- 補足: 実行環境で OpenTelemetry OTLP exporter (`localhost:4318`) が未起動のためエクスポート警告が出ましたが、テストの合否には影響しませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ec51ee78832c80810c156e6f5b38)