### PR TITLE
planner: add regression tests for legacy normalize boundary

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -75,3 +75,19 @@
   - OpenTelemetry exporter が `localhost:4318` 未起動のため warning ログが出るが、テスト自体は成功。
 - 残課題:
   - `_normalize_plan_json()` の適用条件をさらに絞り、legacy state 移行用途へ段階的に限定する。
+
+## 追加スライス (2026-04-19, 4)
+- 変更概要:
+  - planner の legacy normalize 境界に対する回帰テストを追加し、`arguments.coordinates` の数値 coercion・`notes` の辞書化・`clarification_needed` enum 補正を固定化。
+  - top-level `clarification_needed` が不正値でも `data_gap` へ補正され、parse 主経路が制御された挙動を維持することを検証。
+- 主な変更ファイル:
+  - `tests/test_planner_responses_payload.py`
+- 互換性影響:
+  - 実装変更なし（テスト追加のみ）。
+  - legacy normalize を縮小する際に壊しやすい境界（型揺れ・enum 揺れ）を先に固定。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（9 passed）。
+- 残課題:
+  - `_normalize_plan_json()` の適用範囲を旧 state / 外部 legacy データ境界へ限定し、新規 LLM 出力での常用経路から段階的に除去する。

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -114,3 +114,26 @@ async def test_plan_graph_uses_refusal_message_as_controlled_chat_fallback() -> 
     assert plan_out.blocking is True
     assert plan_out.clarification_needed == "confirmation"
     assert any(item.get("label") == "plan_refusal" for item in plan_out.backlog)
+
+
+@pytest.mark.anyio
+async def test_plan_graph_legacy_normalize_coerces_arguments_shape() -> None:
+    plan_out = await _invoke_graph_with_output(
+        '{"plan":["x=10,z=20へ移動"],"resp":"了解","intent":"move",'
+        '"arguments":{"coordinates":{"x":"10","y":"64.0","z":"oops"},'
+        '"notes":"橋の近く","clarification_needed":"unknown"}}'
+    )
+    assert plan_out.plan == ["x=10,z=20へ移動"]
+    assert plan_out.arguments.coordinates == {"x": 10, "y": 64}
+    assert plan_out.arguments.notes == {"text": "橋の近く"}
+    assert plan_out.arguments.clarification_needed == "data_gap"
+
+
+@pytest.mark.anyio
+async def test_plan_graph_legacy_normalize_coerces_top_level_clarification_enum() -> None:
+    plan_out = await _invoke_graph_with_output(
+        '{"plan":["周辺を確認"],"resp":"確認します","intent":"survey",'
+        '"clarification_needed":"manual_review"}'
+    )
+    assert plan_out.plan == ["周辺を確認"]
+    assert plan_out.clarification_needed == "data_gap"


### PR DESCRIPTION
### Motivation
- Ensure shrinking `_normalize_plan_json()` later will not regress handling of legacy/heterogeneous LLM outputs by locking expected coercions and enum corrections in tests.
- Make the planner's legacy-normalize boundary explicit so future refactors can safely remove repair logic with confidence. 

### Description
- Added two regression tests to `tests/test_planner_responses_payload.py` that verify legacy-normalize behavior for `arguments.coordinates` coercion, `arguments.notes` string->dict conversion, and `clarification_needed` enum correction at both argument and top-level positions. 
- Updated `docs/refactor/phase4.md` with an added slice documenting the test additions, rationale, commands and remaining tasks. 
- No production code behavior was changed; this PR only adds tests and documentation to protect the existing normalize fallback boundary. 

### Testing
- Ran `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py` and observed `9 passed` (tests succeeded). 
- Tests passed despite transient OpenTelemetry exporter connection warnings, which did not affect test outcomes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ed8d3950832c9ebf9c990094c349)