### PR TITLE
docs: refresh Phase 0 baseline to reflect setup-dependent Python test results

### DIFF
--- a/docs/refactor/baseline.md
+++ b/docs/refactor/baseline.md
@@ -6,7 +6,8 @@
 
 | コンポーネント | コマンド | 結果 | 補足 |
 |---|---|---|---|
-| Python tests | `python -m pytest tests` | ❌ 失敗 | 25 件が import エラーで収集失敗（`agent`, `actions`, `runtime` などの `ModuleNotFoundError`）。 |
+| Python tests (without setup) | `python -m pytest tests` | ❌ 失敗 | 25 件が import エラーで収集失敗（`agent`, `actions`, `runtime` などの `ModuleNotFoundError`）。 |
+| Python tests (after setup) | `.venv/bin/python -m pytest tests` | ✅ 成功 | `bash scripts/setup-python-env.sh` 実行後は 97 passed。`OTEL_EXPORTER_OTLP_ENDPOINT` 未起動による export warning のみ発生。 |
 | Node tests | `bash scripts/run-node-bot.sh test` | ❌ 失敗 | 実行環境の Node が `v20.19.6` のため、スクリプト要件 (`22+`) で停止。 |
 | Node build | `bash scripts/run-node-bot.sh build` | ❌ 失敗 | 上記と同じく Node 22 未満で停止。 |
 | Bridge build | `bash scripts/build-bridge-plugin.sh` | ✅ 成功 | `shadowJar` まで成功（UP-TO-DATE 含む）。 |
@@ -26,7 +27,7 @@
   - `python -m python`（互換エントリとして残存）
 - 補足:
   - `scripts/run-python-agent.sh` は `sys.path` hack なしで起動する。
-  - テスト失敗は import パスの互換崩れが示唆される（Phase 2 完了条件の再確認対象）。
+  - テスト実行は editable install 前提（`bash scripts/setup-python-env.sh`）で安定する。
 
 ### Node (`node-bot/`)
 
@@ -111,7 +112,7 @@
 
 ## 5. 既知問題（Phase 0 時点）
 
-- Python テストが import エラーで収集段階から失敗し、ベースラインとして不安定。
+- Python テストは依存導入前だと import エラーで失敗するが、`bash scripts/setup-python-env.sh` 後は `.venv/bin/python -m pytest tests` で 97 passed。
 - Node の baseline 実行は Node 22+ 前提のため、CI/開発環境でのバージョン固定が必須。
 - Compose baseline は実行環境依存（docker 未インストール）で検証不能。
 - Compose の Python サービスに `PYTHONPATH` 依存が残り、package 化方針との整合確認が必要。
@@ -127,17 +128,19 @@
   - ドキュメント更新のみ（実行挙動の変更なし）。
 - 実行したコマンド:
   - `python -m pytest tests`
+  - `bash scripts/setup-python-env.sh`
+  - `.venv/bin/python -m pytest tests`
   - `bash scripts/run-node-bot.sh test`
   - `bash scripts/run-node-bot.sh build`
   - `bash scripts/build-bridge-plugin.sh`
   - `cd bridge-plugin && gradle test`
   - `docker compose config`
 - テスト結果:
-  - Python: 失敗（import エラー 25 件）
+  - Python: 条件付き（未セットアップ時は import エラー 25 件 / セットアップ後は 97 passed）
   - Node test/build: 失敗（Node.js 22+ 不足）
   - Bridge build/test: 成功
   - Compose config: 失敗（docker コマンド無し）
 - 残課題:
-  - Python import 経路を package 化正本へ揃えるまで、テスト再現性が低い。
+  - Python テストは環境セットアップ前提のため、ローカル実行手順を README/CI と常に同期する必要がある。
   - Node 実行環境を 22 系に統一する仕組み（CI/開発双方）の継続確認が必要。
   - Docker 不在環境でも確認可能な代替チェックの整備が必要。


### PR DESCRIPTION
### Motivation
- Make the Phase 0 baseline actionable by separating environment-bootstrap failures from genuine code regressions so later phases can correctly identify what a change broke. 
- Clarify local developer instructions and CI expectations by documenting the editable-install setup required for reliable Python test runs.

### Description
- Update `docs/refactor/baseline.md` to split the Python baseline into `Python tests (without setup)` and `Python tests (after setup)` and to clarify known issues and remaining tasks. 
- Record that running `bash scripts/setup-python-env.sh` produces an editable install and stabilizes test execution. 
- Adjust wording around Python test preconditions and local/CI synchronization in the Phase 0 report to improve change-impact diagnosis.

### Testing
- Ran `python -m pytest tests` before setup which failed during collection (import errors for top-level modules). 
- Executed `bash scripts/setup-python-env.sh` to create `.venv` and install dependencies, then ran `.venv/bin/python -m pytest tests` which succeeded (`97 passed`) with only OpenTelemetry export warnings. 
- Ran Node build/test via `bash scripts/run-node-bot.sh test` / `build` which failed due to Node.js being `v20.x` while the project requires `22+`. 
- Ran Bridge build and tests (`bash scripts/build-bridge-plugin.sh` and `cd bridge-plugin && gradle test`) which succeeded. 
- Ran `docker compose config` which failed in this environment because the `docker` command is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4eebd2018832c8578819dbc5485f2)