### PR TITLE
planner: Responses の structured output を優先し legacy normalize 依存を縮小

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -91,3 +91,23 @@
   - 成功（9 passed）。
 - 残課題:
   - `_normalize_plan_json()` の適用範囲を旧 state / 外部 legacy データ境界へ限定し、新規 LLM 出力での常用経路から段階的に除去する。
+
+## 追加スライス (2026-04-19, 5)
+- 変更概要:
+  - planner の parse 経路で Responses API の structured output (`output_parsed` / `content[].parsed`) を優先して検証するように変更し、schema-first の主経路を文字列 JSON parse に依存しない形へ整理。
+  - `structured_output` が取得できる場合は legacy `_normalize_plan_json()` を経由しないようにし、normalize は文字列出力のみの後方互換境界へ限定。
+  - 回帰テストを追加し、`output_text` が壊れていても `output_parsed` が正常なら `PlanOut` を復元できることを固定化。
+- 主な変更ファイル:
+  - `python/planner/prompts.py`
+  - `python/planner/graph.py`
+  - `tests/test_planner_responses_payload.py`
+- 互換性影響:
+  - schema-first 経路の堅牢性が向上し、structured output を返すモデル応答で JSON repair 依存が減少。
+  - legacy normalize は後方互換（非構造化文字列）に限定され、段階的除去に向けた境界が明確化。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（10 passed）。
+- 残課題:
+  - `structured_output` 自体が schema 不整合だった場合の error taxonomy を planner/domain で明確化する。
+  - `_normalize_plan_json()` の責務を旧 state migration へさらに限定する。

--- a/python/planner/graph.py
+++ b/python/planner/graph.py
@@ -36,6 +36,7 @@ from .prompts import (
     build_responses_input,
     build_user_prompt,
     extract_refusal_text,
+    extract_structured_output,
     extract_output_text,
 )
 from .state import UnifiedPlanState, record_recovery_hints, record_structured_step, logger
@@ -325,28 +326,48 @@ def build_plan_graph(
             )
             return result
 
+        response = state.get("response")
+        structured_output = extract_structured_output(response) if response is not None else None
         raw_content = state.get("content") or ""
         try:
-            plan_data = PlanOut.model_validate_json(raw_content)
+            if structured_output is not None:
+                plan_data = PlanOut.model_validate(structured_output)
+            else:
+                plan_data = PlanOut.model_validate_json(raw_content)
         except Exception as primary_exc:
-            normalized_content = _normalize_plan_json(raw_content)
-            try:
-                plan_data = PlanOut.model_validate_json(normalized_content)
-                logger.warning(
-                    "plan graph used legacy JSON normalize fallback: %s",
-                    primary_exc.__class__.__name__,
-                )
-            except Exception as secondary_exc:
-                logger.exception("plan graph failed to parse JSON plan")
+            if structured_output is None:
+                normalized_content = _normalize_plan_json(raw_content)
+                try:
+                    plan_data = PlanOut.model_validate_json(normalized_content)
+                    logger.warning(
+                        "plan graph used legacy JSON normalize fallback: %s",
+                        primary_exc.__class__.__name__,
+                    )
+                except Exception as secondary_exc:
+                    logger.exception("plan graph failed to parse JSON plan")
+                    priority = await manager.mark_failure()
+                    result = {"parse_error": str(secondary_exc), "priority": priority}
+                    result.update(
+                        record_structured_step(
+                            state,
+                            step_label="parse_plan",
+                            inputs={"content_preview": raw_content[:120]},
+                            outputs={"priority": priority},
+                            error=str(secondary_exc),
+                        )
+                    )
+                    return result
+            else:
+                logger.exception("plan graph failed to parse structured plan")
                 priority = await manager.mark_failure()
-                result = {"parse_error": str(secondary_exc), "priority": priority}
+                result = {"parse_error": str(primary_exc), "priority": priority}
                 result.update(
                     record_structured_step(
                         state,
                         step_label="parse_plan",
-                        inputs={"content_preview": raw_content[:120]},
+                        inputs={"content_preview": raw_content[:120], "used_structured_output": True},
                         outputs={"priority": priority},
-                        error=str(secondary_exc),
+                        error=str(primary_exc),
                     )
                 )
                 return result

--- a/python/planner/prompts.py
+++ b/python/planner/prompts.py
@@ -123,6 +123,23 @@ def extract_output_text(response: Response) -> str:
     return ""
 
 
+def extract_structured_output(response: Response) -> Dict[str, Any] | None:
+    """Responses API の structured output を辞書として取り出す。"""
+
+    parsed = getattr(response, "output_parsed", None)
+    if isinstance(parsed, dict):
+        return parsed
+
+    for item in response.output or []:
+        if getattr(item, "type", None) != "message":
+            continue
+        for content in getattr(item, "content", []):
+            candidate = getattr(content, "parsed", None)
+            if isinstance(candidate, dict):
+                return candidate
+    return None
+
+
 def extract_refusal_text(response: Response) -> str:
     """Responses API の拒否メッセージを安全に抽出する。"""
 
@@ -154,4 +171,5 @@ __all__ = [
     "build_user_prompt",
     "extract_refusal_text",
     "extract_output_text",
+    "extract_structured_output",
 ]

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -40,25 +40,42 @@ def test_build_responses_payload_falls_back_to_json_object_without_schema() -> N
 
 
 class _FakeResponses:
-    def __init__(self, output_text: str, output: list[object] | None = None) -> None:
+    def __init__(
+        self,
+        output_text: str,
+        output: list[object] | None = None,
+        response_attrs: dict[str, object] | None = None,
+    ) -> None:
         self._output_text = output_text
         self._output = output or []
+        self._response_attrs = response_attrs or {}
 
     async def create(self, **_: object) -> object:
-        return type("FakeResponse", (), {"output_text": self._output_text, "output": self._output})()
+        attrs = {"output_text": self._output_text, "output": self._output}
+        attrs.update(self._response_attrs)
+        return type("FakeResponse", (), attrs)()
 
 
 class _FakeAsyncClient:
-    def __init__(self, output_text: str, output: list[object] | None = None) -> None:
-        self.responses = _FakeResponses(output_text, output)
+    def __init__(
+        self,
+        output_text: str,
+        output: list[object] | None = None,
+        response_attrs: dict[str, object] | None = None,
+    ) -> None:
+        self.responses = _FakeResponses(output_text, output, response_attrs)
 
 
-async def _invoke_graph_with_output(output_text: str, output: list[object] | None = None) -> PlanOut:
+async def _invoke_graph_with_output(
+    output_text: str,
+    output: list[object] | None = None,
+    response_attrs: dict[str, object] | None = None,
+) -> PlanOut:
     config = _make_config()
     graph = build_plan_graph(
         config,
         priority_manager=PlanPriorityManager(config),
-        async_client_factory=lambda: _FakeAsyncClient(output_text, output),
+        async_client_factory=lambda: _FakeAsyncClient(output_text, output, response_attrs),
         payload_builder=lambda system_prompt, user_prompt: {
             "model": config.model,
             "input": [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
@@ -137,3 +154,21 @@ async def test_plan_graph_legacy_normalize_coerces_top_level_clarification_enum(
     )
     assert plan_out.plan == ["周辺を確認"]
     assert plan_out.clarification_needed == "data_gap"
+
+
+@pytest.mark.anyio
+async def test_plan_graph_prefers_structured_output_without_legacy_normalize() -> None:
+    plan_out = await _invoke_graph_with_output(
+        "not-json",
+        response_attrs={
+            "output_parsed": {
+                "plan": ["丸石を10個掘る"],
+                "resp": "掘ります",
+                "intent": "mine",
+                "clarification_needed": "none",
+            }
+        },
+    )
+    assert plan_out.plan == ["丸石を10個掘る"]
+    assert plan_out.intent == "mine"
+    assert plan_out.resp != "了解しました。"


### PR DESCRIPTION
### Motivation
- Responses API が返す構造化出力 (`output_parsed` / `content[].parsed`) を優先して検証することで、文字列 JSON の修復ロジックに依存しない schema-first 経路を強化するためです。
- 既存の `_normalize_plan_json()` は後方互換のために残すものの、常用経路から段階的に縮小して将来の除去を容易にすることを目的としています。

### Description
- `python/planner/prompts.py` に `extract_structured_output()` を追加して、Responses API の `output_parsed` や `content[].parsed` を辞書として安全に取り出せるようにしました。 
- `python/planner/graph.py` の `parse_plan` ロジックを修正し、`response` に対する `structured_output` を優先して `PlanOut.model_validate()` を実行し、`structured_output` がある場合は legacy の `_normalize_plan_json()` を経由しないようにしました。 
- テスト `tests/test_planner_responses_payload.py` を拡張し、フェイクレスポンスに `output_parsed` を注入できるようにして「`output_text` が壊れていても `output_parsed` から `PlanOut` が復元される」ケースを追加しました。 
- `docs/refactor/phase4.md` に今回のスライス（structured output 優先化）の記録を追記しました。 

### Testing
- `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py` を実行し、該当テストファイルの自動テストは `10 passed` で成功しました。 
- 変更は該当 planner 回帰テストに限定して検証しており、追加で planner 周辺の他テストスイートを走らせることを推奨します。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f15c9798832cb4d140499933d7c2)