### PR TITLE
planner: parse失敗の error taxonomy を追加して回帰テストを拡張

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -111,3 +111,22 @@
 - 残課題:
   - `structured_output` 自体が schema 不整合だった場合の error taxonomy を planner/domain で明確化する。
   - `_normalize_plan_json()` の責務を旧 state migration へさらに限定する。
+
+
+## 追加スライス (2026-04-20)
+- 変更概要:
+  - planner の parse 失敗を可観測化するため、`parse_error_code` を導入し `structured_output_schema_mismatch` / `plan_json_decode_failed` などの安定コードへ分類するように更新。
+  - `parse_plan` ノードの structured output 失敗・JSON 失敗の両経路で同一形式のエラー分類を返し、`record_structured_step` の outputs にも分類コードを記録するようにした。
+  - 回帰テストを追加し、schema 不整合な `output_parsed` と不正 JSON 文字列の双方で `parse_error_code` が期待どおり返ることを固定化した。
+- 主な変更ファイル:
+  - `python/planner/graph.py`
+  - `tests/test_planner_responses_payload.py`
+- 互換性影響:
+  - planner のフォールバック動作（安全な `PlanOut(plan=[], resp="了解しました。")`）は維持。
+  - 失敗時に機械可読な taxonomy を追加したため、後続のメトリクス集計・障害切り分けが容易になった。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（12 passed）。
+- 残課題:
+  - `_normalize_plan_json()` を旧 state migration / 外部 legacy 境界へさらに限定し、主経路から段階的に除去する。

--- a/python/planner/graph.py
+++ b/python/planner/graph.py
@@ -5,6 +5,8 @@ import asyncio
 import json
 from typing import Any, Callable, Dict, List
 
+from pydantic import ValidationError
+
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from opentelemetry.trace import Status, StatusCode
@@ -141,6 +143,23 @@ def _normalize_plan_json(content: str) -> str:
 
     return json.dumps(data, ensure_ascii=False)
 
+
+
+
+def _classify_plan_parse_error(exc: Exception, *, used_structured_output: bool) -> str:
+    """Plan parse 失敗を分類し、可観測性向けの安定コードへ変換する。"""
+
+    if isinstance(exc, ValidationError):
+        try:
+            error_types = {str(item.get("type", "")) for item in exc.errors()}
+        except Exception:  # noqa: BLE001 - エラー分類を失敗させないため防御
+            error_types = set()
+        if "json_invalid" in error_types:
+            return "plan_json_decode_failed"
+        return "structured_output_schema_mismatch" if used_structured_output else "plan_schema_validation_failed"
+    if isinstance(exc, json.JSONDecodeError):
+        return "plan_json_decode_failed"
+    return "plan_parse_unknown"
 
 def _extract_recovery_hints_from_context(state: UnifiedPlanState) -> List[str]:
     hints: List[str] = []
@@ -344,29 +363,39 @@ def build_plan_graph(
                         primary_exc.__class__.__name__,
                     )
                 except Exception as secondary_exc:
-                    logger.exception("plan graph failed to parse JSON plan")
+                    parse_error_code = _classify_plan_parse_error(secondary_exc, used_structured_output=False)
+                    logger.exception("plan graph failed to parse JSON plan (%s)", parse_error_code)
                     priority = await manager.mark_failure()
-                    result = {"parse_error": str(secondary_exc), "priority": priority}
+                    result = {
+                        "parse_error": str(secondary_exc),
+                        "parse_error_code": parse_error_code,
+                        "priority": priority,
+                    }
                     result.update(
                         record_structured_step(
                             state,
                             step_label="parse_plan",
                             inputs={"content_preview": raw_content[:120]},
-                            outputs={"priority": priority},
+                            outputs={"priority": priority, "parse_error_code": parse_error_code},
                             error=str(secondary_exc),
                         )
                     )
                     return result
             else:
-                logger.exception("plan graph failed to parse structured plan")
+                parse_error_code = _classify_plan_parse_error(primary_exc, used_structured_output=True)
+                logger.exception("plan graph failed to parse structured plan (%s)", parse_error_code)
                 priority = await manager.mark_failure()
-                result = {"parse_error": str(primary_exc), "priority": priority}
+                result = {
+                    "parse_error": str(primary_exc),
+                    "parse_error_code": parse_error_code,
+                    "priority": priority,
+                }
                 result.update(
                     record_structured_step(
                         state,
                         step_label="parse_plan",
                         inputs={"content_preview": raw_content[:120], "used_structured_output": True},
-                        outputs={"priority": priority},
+                        outputs={"priority": priority, "parse_error_code": parse_error_code},
                         error=str(primary_exc),
                     )
                 )

--- a/python/planner/state.py
+++ b/python/planner/state.py
@@ -20,6 +20,7 @@ class UnifiedPlanState(TypedDict, total=False):
     content: str
     plan_out: Any
     parse_error: str
+    parse_error_code: str
     llm_error: str
     priority: str
     fallback_plan_out: Any

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -66,11 +66,11 @@ class _FakeAsyncClient:
         self.responses = _FakeResponses(output_text, output, response_attrs)
 
 
-async def _invoke_graph_with_output(
+async def _invoke_graph_with_output_state(
     output_text: str,
     output: list[object] | None = None,
     response_attrs: dict[str, object] | None = None,
-) -> PlanOut:
+) -> dict[str, object]:
     config = _make_config()
     graph = build_plan_graph(
         config,
@@ -85,6 +85,15 @@ async def _invoke_graph_with_output(
 
     result = await graph.ainvoke({"user_msg": "test", "context": {}, "structured_events": []})
     assert isinstance(result.get("plan_out"), PlanOut)
+    return result
+
+
+async def _invoke_graph_with_output(
+    output_text: str,
+    output: list[object] | None = None,
+    response_attrs: dict[str, object] | None = None,
+) -> PlanOut:
+    result = await _invoke_graph_with_output_state(output_text, output, response_attrs)
     return result["plan_out"]
 
 
@@ -172,3 +181,22 @@ async def test_plan_graph_prefers_structured_output_without_legacy_normalize() -
     assert plan_out.plan == ["丸石を10個掘る"]
     assert plan_out.intent == "mine"
     assert plan_out.resp != "了解しました。"
+
+
+@pytest.mark.anyio
+async def test_plan_graph_sets_structured_parse_error_code_on_schema_mismatch() -> None:
+    result = await _invoke_graph_with_output_state(
+        "",
+        response_attrs={"output_parsed": {"plan": "move", "resp": "了解"}},
+    )
+    assert result.get("parse_error_code") == "structured_output_schema_mismatch"
+    assert isinstance(result.get("plan_out"), PlanOut)
+    assert result["plan_out"].resp == "了解しました。"
+
+
+@pytest.mark.anyio
+async def test_plan_graph_sets_json_parse_error_code_on_invalid_output() -> None:
+    result = await _invoke_graph_with_output_state("not-json")
+    assert result.get("parse_error_code") == "plan_json_decode_failed"
+    assert isinstance(result.get("plan_out"), PlanOut)
+    assert result["plan_out"].resp == "了解しました。"


### PR DESCRIPTION
### Motivation
- planner の `parse_plan` で発生する失敗を機械可読に分類し、可観測性と障害解析の精度を上げるために `parse_error_code` を導入する。
- structured output（`output_parsed`）と文字列 JSON の双方で失敗種別を安定したコードで返すことでメトリクスやアラートの集計を容易にする。

### Description
- `python/planner/graph.py` に `_classify_plan_parse_error` を追加し、`ValidationError` や JSON decode エラーなどを `plan_json_decode_failed` / `structured_output_schema_mismatch` / `plan_schema_validation_failed` 等へ分類するロジックを実装した。 
- `parse_plan` の失敗経路に `parse_error_code` を含めて返し、`record_structured_step` の `outputs` にも分類コードを記録するように変更した。 
- LangGraph の state 型 `UnifiedPlanState` に `parse_error_code` を追加してノード間で分類結果を保持できるようにした（`python/planner/state.py`）。
- テスト補助を拡張してグラフの最終 state を直接検証可能にし、schema 不整合な `output_parsed` と不正 JSON の両ケースで `parse_error_code` が付与される回帰テストを追加した（`tests/test_planner_responses_payload.py`）。
- Phase 4 ドキュメント `docs/refactor/phase4.md` に今回のスライスの説明を追記した。
- 変更対象ファイル: `python/planner/graph.py`, `python/planner/state.py`, `tests/test_planner_responses_payload.py`, `docs/refactor/phase4.md`。

### Testing
- 実行コマンド: `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`。 
- 結果: 全テスト成功（`12 passed`）。
- 備考: OpenTelemetry exporter (`localhost:4318`) 未起動による警告ログが出力されるが、テスト自体は成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5907824c8832cb2f29accdf06a8f4)