### PR TITLE
planner: legacy normalizeの適用条件を旧JSON境界へ限定

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -130,3 +130,21 @@
   - 成功（12 passed）。
 - 残課題:
   - `_normalize_plan_json()` を旧 state migration / 外部 legacy 境界へさらに限定し、主経路から段階的に除去する。
+
+## 追加スライス (2026-04-20, 2)
+- 変更概要:
+  - planner の parse 経路で legacy `_normalize_plan_json()` を発火させる条件を見直し、JSON として壊れている payload (`json_invalid`) では normalize を試みず即時に制御された失敗へ分類するようにした。
+  - `_should_use_legacy_normalize` を追加し、legacy normalize を「schema mismatch を持つ JSON 文字列境界」に限定した。
+  - 回帰テストを追加し、非 JSON payload 時に normalize が呼ばれないことを monkeypatch で固定化した。
+- 主な変更ファイル:
+  - `python/planner/graph.py`
+  - `tests/test_planner_responses_payload.py`
+- 互換性影響:
+  - schema-first の正常系と既存 fallback (`PlanOut(plan=[], resp="了解しました。")`) は維持。
+  - 非 JSON 文字列に対する不要な normalize 試行がなくなり、legacy fallback の責務が狭まった。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（13 passed）。
+- 残課題:
+  - `_normalize_plan_json()` の責務を、旧 state migration / 外部 legacy boundary coercion のみへさらに限定する。

--- a/python/planner/graph.py
+++ b/python/planner/graph.py
@@ -161,6 +161,23 @@ def _classify_plan_parse_error(exc: Exception, *, used_structured_output: bool) 
         return "plan_json_decode_failed"
     return "plan_parse_unknown"
 
+
+def _should_use_legacy_normalize(raw_content: str, exc: Exception) -> bool:
+    """legacy normalize の適用条件を、旧 JSON 境界に限定する。"""
+
+    if not raw_content.strip():
+        return False
+    if not isinstance(exc, ValidationError):
+        return False
+    try:
+        error_types = {str(item.get("type", "")) for item in exc.errors()}
+    except Exception:  # noqa: BLE001 - 補助判定失敗時は安全側で normalize しない
+        return False
+    if "json_invalid" in error_types:
+        # 文字列自体が JSON として壊れているケースは修理対象にしない。
+        return False
+    return True
+
 def _extract_recovery_hints_from_context(state: UnifiedPlanState) -> List[str]:
     hints: List[str] = []
     context = state.get("context") or {}
@@ -355,19 +372,39 @@ def build_plan_graph(
                 plan_data = PlanOut.model_validate_json(raw_content)
         except Exception as primary_exc:
             if structured_output is None:
-                normalized_content = _normalize_plan_json(raw_content)
-                try:
-                    plan_data = PlanOut.model_validate_json(normalized_content)
-                    logger.warning(
-                        "plan graph used legacy JSON normalize fallback: %s",
-                        primary_exc.__class__.__name__,
-                    )
-                except Exception as secondary_exc:
-                    parse_error_code = _classify_plan_parse_error(secondary_exc, used_structured_output=False)
+                if _should_use_legacy_normalize(raw_content, primary_exc):
+                    normalized_content = _normalize_plan_json(raw_content)
+                    try:
+                        plan_data = PlanOut.model_validate_json(normalized_content)
+                        logger.warning(
+                            "plan graph used legacy JSON normalize fallback: %s",
+                            primary_exc.__class__.__name__,
+                        )
+                    except Exception as secondary_exc:
+                        parse_error_code = _classify_plan_parse_error(secondary_exc, used_structured_output=False)
+                        logger.exception("plan graph failed to parse JSON plan (%s)", parse_error_code)
+                        priority = await manager.mark_failure()
+                        result = {
+                            "parse_error": str(secondary_exc),
+                            "parse_error_code": parse_error_code,
+                            "priority": priority,
+                        }
+                        result.update(
+                            record_structured_step(
+                                state,
+                                step_label="parse_plan",
+                                inputs={"content_preview": raw_content[:120]},
+                                outputs={"priority": priority, "parse_error_code": parse_error_code},
+                                error=str(secondary_exc),
+                            )
+                        )
+                        return result
+                else:
+                    parse_error_code = _classify_plan_parse_error(primary_exc, used_structured_output=False)
                     logger.exception("plan graph failed to parse JSON plan (%s)", parse_error_code)
                     priority = await manager.mark_failure()
                     result = {
-                        "parse_error": str(secondary_exc),
+                        "parse_error": str(primary_exc),
                         "parse_error_code": parse_error_code,
                         "priority": priority,
                     }
@@ -377,7 +414,7 @@ def build_plan_graph(
                             step_label="parse_plan",
                             inputs={"content_preview": raw_content[:120]},
                             outputs={"priority": priority, "parse_error_code": parse_error_code},
-                            error=str(secondary_exc),
+                            error=str(primary_exc),
                         )
                     )
                     return result

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -1,4 +1,5 @@
 from planner import _build_responses_payload
+import planner.graph as planner_graph
 from planner.graph import build_plan_graph
 from planner.models import PlanOut
 from planner.priority import PlanPriorityManager
@@ -200,3 +201,13 @@ async def test_plan_graph_sets_json_parse_error_code_on_invalid_output() -> None
     assert result.get("parse_error_code") == "plan_json_decode_failed"
     assert isinstance(result.get("plan_out"), PlanOut)
     assert result["plan_out"].resp == "了解しました。"
+
+
+@pytest.mark.anyio
+async def test_plan_graph_skips_legacy_normalize_for_non_json_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_if_called(_: str) -> str:
+        raise AssertionError("legacy normalize should not run for non-JSON payload")
+
+    monkeypatch.setattr(planner_graph, "_normalize_plan_json", _raise_if_called)
+    result = await _invoke_graph_with_output_state("not-json")
+    assert result.get("parse_error_code") == "plan_json_decode_failed"


### PR DESCRIPTION
### Motivation
- LLM の非構造化出力に対して広く legacy の JSON normalize を試みると不必要な修復が走り、schema-first の主経路の保証を弱めるため、normalize の適用範囲を絞る必要があった。 

### Description
- `python/planner/graph.py` に `_should_use_legacy_normalize` を追加して、legacy normalize を `ValidationError` の schema-mismatch（かつ JSON として壊れていない文字列境界）に限定しました。 
- `parse_plan` の例外処理を更新し、非 JSON（`json_invalid` 相当）のケースでは `_normalize_plan_json()` を呼ばず即時に `parse_error_code` を返すようにしました。 
- 回帰テストを `tests/test_planner_responses_payload.py` に追加し、非 JSON payload 時に legacy normalize が呼ばれないことを `monkeypatch` で固定化しました。 
- `docs/refactor/phase4.md` を更新して今回の追加スライス（変更点・影響・テスト結果・残課題）を追記しました。 

### Testing
- 実行コマンド: `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py` was run. 
- 結果: `13 passed`（すべて成功）。
- 備考: テスト実行時に OpenTelemetry exporter の `localhost:4318` 未接続による warning が出力されましたが、テストは成功しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e591f542dc832ca4a5f319c88fc999)