### PR TITLE
planner: LLM呼び出しエラーの parse_error_code 分類を追加

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -148,3 +148,22 @@
   - 成功（13 passed）。
 - 残課題:
   - `_normalize_plan_json()` の責務を、旧 state migration / 外部 legacy boundary coercion のみへさらに限定する。
+
+
+## 追加スライス (2026-04-20, 3)
+- 変更概要:
+  - `parse_plan` ノードに LLM 呼び出し失敗時の安定エラー分類を追加し、`parse_error_code` として `llm_call_failed` / `llm_timeout` / `llm_refusal` を返せるようにした。
+  - `record_structured_step` にも同じ `parse_error_code` を記録し、呼び出し失敗時の可観測性を JSON parse 失敗経路と揃えた。
+  - 回帰テストを追加し、LLM 呼び出し timeout 時に `parse_error_code=llm_timeout` が返ることを固定化した。
+- 主な変更ファイル:
+  - `python/planner/graph.py`
+  - `tests/test_planner_responses_payload.py`
+- 互換性影響:
+  - planner の安全フォールバック (`PlanOut(plan=[], resp=...)`) は維持。
+  - 失敗時に機械可読コードが増え、LLM 呼び出し障害と JSON/schema 障害を分離して集計可能になった。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（14 passed）。
+- 残課題:
+  - `_normalize_plan_json()` の責務を旧 state migration / 外部 legacy boundary coercion へさらに限定する。

--- a/python/planner/graph.py
+++ b/python/planner/graph.py
@@ -220,6 +220,17 @@ async def _compose_pre_action_follow_up(
     return "作業内容に不確実な点があるため、追加の指示をいただけますか？"
 
 
+def _classify_llm_error_for_parse(error_text: str) -> str:
+    """LLM 呼び出し失敗を parse ノード用の安定コードに分類する。"""
+
+    lowered = (error_text or "").lower()
+    if "timeout" in lowered:
+        return "llm_timeout"
+    if "refusal" in lowered:
+        return "llm_refusal"
+    return "llm_call_failed"
+
+
 def build_plan_graph(
     config: PlannerConfig,
     *,
@@ -347,7 +358,12 @@ def build_plan_graph(
     async def parse_plan(state: UnifiedPlanState) -> Dict[str, Any]:
         if state.get("llm_error"):
             priority = state.get("priority") or await manager.mark_failure()
-            result: Dict[str, Any] = {"parse_error": state["llm_error"], "priority": priority}
+            parse_error_code = _classify_llm_error_for_parse(str(state["llm_error"]))
+            result: Dict[str, Any] = {
+                "parse_error": state["llm_error"],
+                "parse_error_code": parse_error_code,
+                "priority": priority,
+            }
             fallback_plan = state.get("fallback_plan_out")
             if fallback_plan is not None:
                 result["fallback_plan_out"] = fallback_plan
@@ -356,7 +372,7 @@ def build_plan_graph(
                     state,
                     step_label="parse_plan",
                     inputs={"has_llm_error": True},
-                    outputs={"priority": priority},
+                    outputs={"priority": priority, "parse_error_code": parse_error_code},
                     error=state.get("llm_error", ""),
                 )
             )

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -67,6 +67,16 @@ class _FakeAsyncClient:
         self.responses = _FakeResponses(output_text, output, response_attrs)
 
 
+class _TimeoutResponses:
+    async def create(self, **_: object) -> object:
+        raise TimeoutError("simulated timeout")
+
+
+class _TimeoutAsyncClient:
+    def __init__(self) -> None:
+        self.responses = _TimeoutResponses()
+
+
 async def _invoke_graph_with_output_state(
     output_text: str,
     output: list[object] | None = None,
@@ -211,3 +221,20 @@ async def test_plan_graph_skips_legacy_normalize_for_non_json_payload(monkeypatc
     monkeypatch.setattr(planner_graph, "_normalize_plan_json", _raise_if_called)
     result = await _invoke_graph_with_output_state("not-json")
     assert result.get("parse_error_code") == "plan_json_decode_failed"
+
+
+@pytest.mark.anyio
+async def test_plan_graph_sets_llm_timeout_error_code_when_call_times_out() -> None:
+    config = _make_config()
+    graph = build_plan_graph(
+        config,
+        priority_manager=PlanPriorityManager(config),
+        async_client_factory=lambda: _TimeoutAsyncClient(),
+        payload_builder=lambda system_prompt, user_prompt: {
+            "model": config.model,
+            "input": [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
+            "text": {"format": {"type": "json_schema"}},
+        },
+    )
+    result = await graph.ainvoke({"user_msg": "test", "context": {}, "structured_events": []})
+    assert result.get("parse_error_code") == "llm_timeout"


### PR DESCRIPTION
### Motivation
- planner の `parse_plan` 経路で LLM 呼び出し失敗が発生した際に、JSON/schema のパース失敗と同様に機械可読なエラー集計ができるように可観測性を向上するため。 

### Description
- `python/planner/graph.py` に `_classify_llm_error_for_parse` を追加し、LLM 呼び出しエラーを `llm_timeout` / `llm_refusal` / `llm_call_failed` の安定コードへ分類するようにした。 
- `parse_plan` の早期エラー経路で `llm_error` を受け取った際に `parse_error_code` を設定し、`record_structured_step` の `outputs` にも同じ `parse_error_code` を残すようにした。 
- テスト `tests/test_planner_responses_payload.py` を拡張し、タイムアウトを模擬する `_TimeoutAsyncClient` を追加して LLM timeout 時に `parse_error_code ==

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59310eae8832cbd5c93d18dcceab4)