### PR TITLE
docs: Phase 0のベースラインを最新実行結果で再採取

### DIFF
--- a/docs/refactor/baseline.md
+++ b/docs/refactor/baseline.md
@@ -1,144 +1,125 @@
-# Baseline Report (Phase 0)
+# Phase 0 Baseline (2026-04-20)
 
-最終更新日: 2026-04-20 (UTC)
+## 目的
 
-## 1. 実行コマンドと結果
+Phase 1 以降で変更による退行を判定できるよう、現行の実行入口・依存・環境差異・検証結果を固定する。
 
-| コンポーネント | コマンド | 結果 | 補足 |
-|---|---|---|---|
-| Python tests | `python -m pytest tests` | ❌ 失敗 | 25 件が import エラーで収集失敗（`agent`, `actions`, `runtime` などの `ModuleNotFoundError`）。 |
-| Node tests | `bash scripts/run-node-bot.sh test` | ❌ 失敗 | 実行環境の Node が `v20.19.6` のため、スクリプト要件 (`22+`) で停止。 |
-| Node build | `bash scripts/run-node-bot.sh build` | ❌ 失敗 | 上記と同じく Node 22 未満で停止。 |
-| Bridge build | `bash scripts/build-bridge-plugin.sh` | ✅ 成功 | `shadowJar` まで成功（UP-TO-DATE 含む）。 |
-| Bridge test | `cd bridge-plugin && gradle test build` | ✅ 成功 | `:test` と `:build` が成功（`./gradlew` は未配置のため Gradle 本体を利用）。 |
-| Compose config | `docker compose config` | ❌ 失敗 | 実行環境に `docker` コマンド無し。 |
+## セッション足場チェック
 
-## 2. 依存と entrypoint の現状一覧
+- 作業ディレクトリ: `/workspace/mc-bot-egent-practice-1`
+- ブランチ: `work`
+- 直近コミット:
+  - `79d4ad3` Merge pull request #154
+  - `0fb1b8d` planner失敗分類にLLM呼び出しエラーコードを追加
+  - `81be104` Merge pull request #153
+- ルート AGENTS.md とサブディレクトリ AGENTS.md の存在を確認
+
+## ベースライン実行結果
+
+| 区分 | コマンド | 結果 | メモ |
+| --- | --- | --- | --- |
+| Python 環境構築 | `bash scripts/setup-python-env.sh` | ✅ 成功 | `.venv` 再作成、`requirements.txt + constraints.txt`、editable install (`mc-bot-agent`) 完了 |
+| Python テスト | `source .venv/bin/activate && python -m pytest tests` | ✅ 成功 | `102 passed`。終了時に OTLP exporter の localhost:4318 接続失敗ログあり（テスト自体は成功） |
+| Node テスト | `bash scripts/run-node-bot.sh test` | ❌ 失敗 | 環境の Node が `v20.19.6` のためガードで停止（22+ 必須） |
+| Node build | `bash scripts/run-node-bot.sh build` | ❌ 失敗 | 同上（Node 22+ 必須） |
+| Bridge build | `bash scripts/build-bridge-plugin.sh` | ✅ 成功 | `shadowJar` 成功 |
+| Bridge test/build | `cd bridge-plugin && (./gradlew \|\| gradle) test build` | ✅ 成功 | `test`, `build` 成功 |
+| Compose 構成確認 | `docker compose config` | ❌ 失敗 | 実行環境に `docker` コマンドが存在しない |
+
+## 既知問題（Phase 0 時点）
+
+1. Node 系コマンドは Node 22 以上が前提。CI/ローカルでのバージョン固定が必要。
+2. `docker compose config` は Docker 非導入環境では検証不可。CI job または Docker 有効環境で補完が必要。
+3. Python テスト成功後に OTLP 送信リトライログが出る。ローカル Collector 非起動時の既知ノイズ。
+
+## 依存とエントリポイント（現状正）
 
 ### Python
 
-- 依存定義:
-  - `requirements.txt` + `constraints.txt`（`scripts/setup-python-env.sh` で利用）
-  - `pyproject.toml`（editable install を前提に併用）
-- 実行 entrypoint:
+- 依存正本: `requirements.txt` + `constraints.txt`
+- パッケージ定義: `pyproject.toml`
+- 実行入口:
   - `bash scripts/run-python-agent.sh`
-  - `python -m mc_bot_agent_entrypoint`（`scripts/run-python-agent.sh` の実行実体）
-  - `python -m python`（互換エントリとして残存）
-- 補足:
-  - `scripts/run-python-agent.sh` は `sys.path` hack なしで起動する。
-  - テスト実行は editable install 前提（`bash scripts/setup-python-env.sh`）で安定する。
-
-### Node (`node-bot/`)
-
-- 依存定義: `node-bot/package.json` + `node-bot/package-lock.json`
-- 実行 entrypoint:
-  - `bash scripts/run-node-bot.sh start|dev|build|test`
-  - `npm run dev` / `npm start`（`node-bot/package.json`）
-- 補足:
-  - スクリプト側で Node.js 22+ を強制チェック。
-  - 初回依存解決は `npm ci`（`node_modules` 不在時）で実行される。
-
-### Bridge (`bridge-plugin/`)
-
-- 依存定義: `bridge-plugin/build.gradle.kts`
-- 実行/ビルド entrypoint:
-  - `bash scripts/build-bridge-plugin.sh`（`shadowJar`）
-  - `cd bridge-plugin && gradle test build`
-- 補足:
-  - 現在の baseline では build/test ともに成功。
-  - 手置き jar 依存が CI で問題化しないかは Phase 1 継続確認対象。
-
-## 3. `.env.example` / README / Compose の差異（Phase 0 観測）
-
-1. 環境テンプレートは `env.dev.example` と `env.prod.example` が追加済みで、`env.example` は互換用として残置されている。
-2. README は `cp env.dev.example .env` を初期導線にし、dev/prod の使い分けを明記している。
-3. `docker-compose.yml` では起動時 install がまだ残っている。
-   - Node: `npm ci && npm run dev`
-   - Python: `pip install -r requirements.txt -c constraints.txt && watchfiles ...`
-4. Compose 側で `PYTHONPATH=/app:/app/python` が設定されており、旧 import 経路との互換レイヤが残存している。
-
-## 4. 主要実行経路ファイル（差分評価用の参照リスト）
-
-### Python planner/runtime
-
-- `python/mc_bot_agent_entrypoint.py`
-- `python/__main__.py`
-- `python/runtime/bootstrap.py`
-- `python/runtime/unified_agent_graph.py`
-- `python/runtime/websocket_server.py`
-- `python/runtime/chat_queue.py`
-- `python/planner/graph.py`
-- `python/planner_config.py`
-- `pyproject.toml`
-- `requirements.txt`
-- `constraints.txt`
-
-### Node bot runtime
-
-- `node-bot/bot.ts`
-- `node-bot/runtime/bootstrap.ts`
-- `node-bot/runtime/server.ts`
-- `node-bot/runtime/agentBridge.ts`
-- `node-bot/runtime/services/chatBridge.ts`
-- `node-bot/runtime/transportEnvelope.ts`
-- `node-bot/runtime/env.ts`
-- `node-bot/package.json`
-- `node-bot/package-lock.json`
-
-### Bridge plugin
-
-- `bridge-plugin/build.gradle.kts`
-- `bridge-plugin/src/main/java/com/example/bridge/AgentBridgePlugin.java`
-- `bridge-plugin/src/main/java/com/example/bridge/http/BridgeHttpServer.java`
-- `bridge-plugin/src/main/java/com/example/bridge/http/handlers/*.java`
-- `bridge-plugin/src/main/java/com/example/bridge/util/CoreProtectFacade.java`
-- `bridge-plugin/src/main/resources/config.yml`
-
-### 契約/起動/運用共通
-
-- `contracts/transport-envelope.schema.json`
-- `scripts/run-python-agent.sh`
-- `scripts/run-python-agent-watch.sh`
-- `scripts/setup-python-env.sh`
-- `scripts/run-node-bot.sh`
-- `scripts/build-bridge-plugin.sh`
-- `docker-compose.yml`
-- `docker-compose.host-services.yml`
-- `README.md`
-- `env.dev.example`
-- `env.prod.example`
-- `env.example`
-
-## 5. 既知問題（Phase 0 時点）
-
-- Python テストは依存導入前だと import エラーで失敗する。
-- Node の baseline 実行は Node 22+ 前提のため、CI/開発環境でのバージョン固定が必須。
-- Compose baseline は実行環境依存（docker 未インストール）で検証不能。
-- Compose の Python サービスに `PYTHONPATH` 依存が残り、package 化方針との整合確認が必要。
-- `bash scripts/run-python-agent.sh --help` は help オプション未対応のため `mc_bot_agent_entrypoint` 実行に進み、モジュール未解決で終了する。
-
-## Phase 0 完了報告
-- 変更概要:
-  - 現時点の実行結果を再採取し、成功/失敗理由を更新。
-  - Python/Node/Bridge の依存・entrypoint・既知リスクを現ツリー基準で棚卸し。
-  - `.env` テンプレート分離済み状態と Compose 実行方式の差分を再確認。
-- 主な変更ファイル:
-  - `docs/refactor/baseline.md`
-- 互換性影響:
-  - ドキュメント更新のみ（実行挙動の変更なし）。
-- 実行したコマンド:
+  - `python -m mc_bot_agent_entrypoint`
+- テスト入口:
   - `python -m pytest tests`
+
+### Node
+
+- 依存正本: `node-bot/package-lock.json`（`npm ci` 前提）
+- 実行入口:
+  - `bash scripts/run-node-bot.sh start`
+  - `bash scripts/run-node-bot.sh dev`
+- 検証入口:
   - `bash scripts/run-node-bot.sh test`
   - `bash scripts/run-node-bot.sh build`
-  - `bash scripts/build-bridge-plugin.sh`
-  - `cd bridge-plugin && gradle test build`
-  - `docker compose config`
-- テスト結果:
-  - Python: 失敗（import エラー 25 件）
-  - Node test/build: 失敗（Node.js 22+ 不足）
-  - Bridge build/test: 成功（Bridge test は `gradle test build` で確認）
-  - Compose config: 失敗（docker コマンド無し）
-- 残課題:
-  - Python テストは環境セットアップ前提のため、ローカル実行手順を README/CI と常に同期する必要がある。
-  - Node 実行環境を 22 系に統一する仕組み（CI/開発双方）の継続確認が必要。
-  - Docker 不在環境でも確認可能な代替チェックの整備が必要。
+
+### Bridge Plugin
+
+- ビルド設定: `bridge-plugin/build.gradle.kts`
+- 実行入口:
+  - `bash scripts/build-bridge-plugin.sh`（`shadowJar`）
+  - `cd bridge-plugin && ./gradlew test build`
+
+### Compose
+
+- 定義ファイル: `docker-compose.yml`, `docker-compose.host-services.yml`
+- 入口:
+  - `docker compose up --build`
+  - `docker compose -f docker-compose.yml -f docker-compose.host-services.yml up --build`
+
+## `.env.example` / README / Compose 差異メモ
+
+1. README と運用導線は `env.dev.example` / `env.prod.example` を正本として案内しており、`env.example` は互換残置の位置づけ。
+2. `docker-compose.yml` の `node-bot` は起動時に `npm ci`、`python-agent` は起動時に `pip install` を実行する構成（Phase 6 で build 時解決へ寄せる対象）。
+3. Compose 内部接続は `COMPOSE_*` 系環境変数で上書きする設計。
+
+## 主要実行経路ファイル一覧（Phase 0 凍結）
+
+- Orchestration / env
+  - `README.md`
+  - `Makefile`
+  - `env.example`
+  - `env.dev.example`
+  - `env.prod.example`
+  - `docker-compose.yml`
+  - `docker-compose.host-services.yml`
+- Python
+  - `pyproject.toml`
+  - `requirements.txt`
+  - `constraints.txt`
+  - `scripts/setup-python-env.sh`
+  - `scripts/run-python-agent.sh`
+  - `python/mc_bot_agent_entrypoint.py`
+- Node
+  - `node-bot/package.json`
+  - `node-bot/package-lock.json`
+  - `scripts/run-node-bot.sh`
+  - `node-bot/bot.ts`
+- Bridge
+  - `scripts/build-bridge-plugin.sh`
+  - `bridge-plugin/build.gradle.kts`
+  - `bridge-plugin/src/main/java/com/example/bridge/AgentBridgePlugin.java`
+
+## 機械更新向けステータス
+
+```json
+{
+  "phase": 0,
+  "captured_at": "2026-04-20",
+  "checks": {
+    "python_setup": "passed",
+    "python_tests": "passed",
+    "node_tests": "failed_node_version",
+    "node_build": "failed_node_version",
+    "bridge_build": "passed",
+    "bridge_test_build": "passed",
+    "docker_compose_config": "failed_docker_missing"
+  },
+  "next_shortest_action": "Phase 1 で CI に Node 22 / Java 21 / Python 3.12 を固定し、Docker 構成検証を自動化する"
+}
+```
+
+## Phase 0 完了条件に対する判定
+
+- ✅ 「後続 Phase が何を壊したか判定できる」ための実行結果・既知失敗理由・主要経路を記録済み。


### PR DESCRIPTION
### Motivation
- Phase 1 以降で変更による退行を自動的に判定できるように、現行の実行入口・依存・実行結果を固定化するためにベースラインを再採取しました。
- 実行可能性やローカル差分（Node/Java/Docker のバージョン差など）を明示して、後続フェーズでの回帰判定材料を用意することを目的とします。

### Description
- `docs/refactor/baseline.md` を更新し、検証コマンド一覧と各コマンドの成功/失敗・補足を記録しました。
- ベースラインには `Python` / `Node` / `Bridge` / `Compose` の実行結果、既知問題、依存とエントリポイント一覧、機械読取可能な JSON ステータスを含めました。
- 変更はドキュメントのみで、実装挙動の変更はありません（コミット済み: `docs/refactor/baseline.md`）。

### Testing
- `bash scripts/setup-python-env.sh` を実行して Python 環境を再構築し、インストールは成功しました。 (成功)
- `source .venv/bin/activate && python -m pytest tests` を実行しテストスイートは `102 passed` で完了しましたが、OTLP exporter の接続リトライログが出ています（Collector 未起動によるノイズ）。 (成功)
- `bash scripts/build-bridge-plugin.sh` と `cd bridge-plugin && (./gradlew || gradle) test build` を実行し、Bridge のビルドとテストは成功しました。 (成功)
- `bash scripts/run-node-bot.sh test` と `bash scripts/run-node-bot.sh build` はローカルの Node.js が `v20.19.6` のためガードで停止し失敗しました（Node 22+ が必須）。 (失敗)
- `docker compose config` はこの環境に `docker` コマンドが無いため検証できませんでした。 (検証不可)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e594caf09c832c834943bc0e8c7726)