### PR TITLE
planner: restrict legacy normalize to coercion-only boundaries

### DIFF
--- a/docs/refactor/phase4.md
+++ b/docs/refactor/phase4.md
@@ -167,3 +167,22 @@
   - 成功（14 passed）。
 - 残課題:
   - `_normalize_plan_json()` の責務を旧 state migration / 外部 legacy boundary coercion へさらに限定する。
+
+## 追加スライス (2026-04-20, 4)
+- 変更概要:
+  - planner の `_should_use_legacy_normalize` 判定を厳格化し、legacy normalize を `arguments` / `constraints` / `backlog` / `clarification_needed` の型揺れ補正に限定した。
+  - `missing` / `extra_forbidden` など構造欠陥は normalize で補修せず、schema-first の `plan_schema_validation_failed` として扱うようにした。
+  - 回帰テストを追加し、必須キー欠落 payload では legacy normalize が呼ばれないことを monkeypatch で固定化した。
+- 主な変更ファイル:
+  - `python/planner/graph.py`
+  - `tests/test_planner_responses_payload.py`
+  - `docs/refactor/phase4.md`
+- 互換性影響:
+  - 正常系と既存の legacy coercion（座標型揺れ補正）は維持。
+  - 構造欠陥を normalize が隠蔽しないため、失敗分類の一貫性が向上。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功（15 passed）。
+- 残課題:
+  - `_normalize_plan_json()` の責務を旧 state migration / 外部 legacy boundary coercion へさらに限定する。

--- a/python/planner/graph.py
+++ b/python/planner/graph.py
@@ -170,12 +170,34 @@ def _should_use_legacy_normalize(raw_content: str, exc: Exception) -> bool:
     if not isinstance(exc, ValidationError):
         return False
     try:
-        error_types = {str(item.get("type", "")) for item in exc.errors()}
+        errors = list(exc.errors())
+        error_types = {str(item.get("type", "")) for item in errors}
     except Exception:  # noqa: BLE001 - 補助判定失敗時は安全側で normalize しない
         return False
     if "json_invalid" in error_types:
         # 文字列自体が JSON として壊れているケースは修理対象にしない。
         return False
+    # 欠落フィールドや想定外キーのような構造欠陥は normalize で補修せず、
+    # schema-first の制御された失敗として扱う。
+    if any(error_type in {"missing", "extra_forbidden"} for error_type in error_types):
+        return False
+    allowed_error_prefixes = {
+        "literal_error",
+        "int_type",
+        "int_parsing",
+        "dict_type",
+        "string_type",
+        "list_type",
+    }
+    if any(not any(error_type.startswith(prefix) for prefix in allowed_error_prefixes) for error_type in error_types):
+        return False
+    allowed_legacy_roots = {"arguments", "constraints", "backlog", "clarification_needed"}
+    for item in errors:
+        loc = item.get("loc", ())
+        if not isinstance(loc, (tuple, list)) or not loc:
+            return False
+        if str(loc[0]) not in allowed_legacy_roots:
+            return False
     return True
 
 def _extract_recovery_hints_from_context(state: UnifiedPlanState) -> List[str]:

--- a/tests/test_planner_responses_payload.py
+++ b/tests/test_planner_responses_payload.py
@@ -224,6 +224,20 @@ async def test_plan_graph_skips_legacy_normalize_for_non_json_payload(monkeypatc
 
 
 @pytest.mark.anyio
+async def test_plan_graph_skips_legacy_normalize_for_missing_required_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_if_called(_: str) -> str:
+        raise AssertionError("legacy normalize should not run for missing required fields")
+
+    monkeypatch.setattr(planner_graph, "_normalize_plan_json", _raise_if_called)
+    result = await _invoke_graph_with_output_state('{"intent":"move"}')
+    assert result.get("parse_error_code") is None
+    assert isinstance(result.get("plan_out"), PlanOut)
+    assert result["plan_out"].next_action == "chat"
+
+
+@pytest.mark.anyio
 async def test_plan_graph_sets_llm_timeout_error_code_when_call_times_out() -> None:
     config = _make_config()
     graph = build_plan_graph(


### PR DESCRIPTION
### Motivation
- Reduce reliance on ad-hoc JSON repair by ensuring schema-first failure semantics are preserved for structural errors.
- Limit `_normalize_plan_json` to only cover benign type/coercion drift so legacy heuristics do not hide missing/extra-field defects.
- Improve observability and error classification so downstream metrics and recovery are consistent with schema validation.

### Description
- Tighten `_should_use_legacy_normalize` in `python/planner/graph.py` to: collect `ValidationError` entries, reject `missing`/`extra_forbidden`, allow only type/coercion error prefixes, and restrict legacy normalize targets to `arguments`/`constraints`/`backlog`/`clarification_needed`.
- Add a unit test `test_plan_graph_skips_legacy_normalize_for_missing_required_fields` in `tests/test_planner_responses_payload.py` to assert legacy normalize is not invoked for required-field-missing payloads.
- Record the change in `docs/refactor/phase4.md` describing the rationale and the observed test results.

### Testing
- Ran `PYTHONPATH=python python -m pytest tests/test_planner_responses_payload.py` and all tests passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59647da70832ca93aa7ca034cc4b3)