### PR TITLE
Phase 5: wire `thread_id` into LangGraph invocations and add regression tests

### DIFF
--- a/docs/refactor/phase5.md
+++ b/docs/refactor/phase5.md
@@ -1,0 +1,23 @@
+# Phase 5 進捗報告
+
+## 追加スライス (2026-04-20)
+
+## Phase 5 完了報告
+- 変更概要:
+  - planner `plan()` 呼び出しで LangGraph `configurable.thread_id` を必ず渡すようにし、context に `thread_id` がある場合は再利用、未指定時は UUID を新規採番するように更新。
+  - これにより checkpointer 導入時に `thread_id` 単位の再開経路へ接続できる呼び出し契約を先行で固定。
+  - `tests/test_planner_thread_config.py` を追加し、`thread_id` 引き継ぎと未指定時採番の両方を回帰テスト化。
+- 主な変更ファイル:
+  - `python/planner/__init__.py`
+  - `tests/test_planner_thread_config.py`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - 既存の planner 出力契約 (`PlanOut`) は変更なし。
+  - context に `thread_id` を入れない既存呼び出しでも互換動作（内部で新規採番）を維持。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_thread_config.py tests/test_planner_responses_payload.py`
+- テスト結果:
+  - 成功。
+- 残課題:
+  - Phase 5 本体として checkpointer 注入ポイント（local SQLite / test InMemory）を追加し、同一 `thread_id` の resume シナリオを統合テストで固定する。
+  - `run_id` / `trace_id` / `thread_id` の役割分離を architecture docs へ明文化する。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,6 +1,6 @@
 {
   "updated_at": "2026-04-20",
-  "current_phase": 4,
+  "current_phase": 5,
   "phases": [
     {
       "phase": 0,
@@ -44,7 +44,7 @@
     {
       "phase": 4,
       "name": "planner を Structured Outputs 化",
-      "status": "in_progress",
+      "status": "completed",
       "artifacts": [
         "docs/refactor/phase4.md",
         "python/planner/__init__.py",
@@ -55,7 +55,12 @@
     {
       "phase": 5,
       "name": "LangGraph persistence / interrupt 化",
-      "status": "pending"
+      "status": "in_progress",
+      "artifacts": [
+        "python/planner/__init__.py",
+        "tests/test_planner_thread_config.py",
+        "docs/refactor/phase5.md"
+      ]
     },
     {
       "phase": 6,

--- a/python/planner/__init__.py
+++ b/python/planner/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import openai
 from typing import Any, Callable, Dict, Optional, Type
+from uuid import uuid4
 
 from langgraph.graph.state import CompiledStateGraph
 from pydantic import BaseModel
@@ -122,6 +123,15 @@ def _get_plan_graph() -> CompiledStateGraph:
     return _PLAN_GRAPH
 
 
+def _resolve_thread_id(context: Dict[str, Any]) -> str:
+    """LangGraph 実行の再開に使う thread_id を決定する。"""
+
+    candidate = context.get("thread_id")
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+    return uuid4().hex
+
+
 async def plan(user_msg: str, context: Dict[str, Any]) -> PlanOut:
     """ユーザーの日本語チャットを Responses API へ投げ、実行プランを復元する。"""
 
@@ -133,7 +143,8 @@ async def plan(user_msg: str, context: Dict[str, Any]) -> PlanOut:
         "context": safe_context,
         "structured_events": [],
     }
-    result = await graph.ainvoke(initial_state)
+    thread_id = _resolve_thread_id(safe_context)
+    result = await graph.ainvoke(initial_state, config={"configurable": {"thread_id": thread_id}})
     plan_out = result.get("plan_out")
 
     def _attach_plan_metadata(plan: PlanOut) -> PlanOut:

--- a/tests/test_planner_thread_config.py
+++ b/tests/test_planner_thread_config.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+import planner
+from planner.models import PlanOut
+
+
+class _FakeGraph:
+    def __init__(self) -> None:
+        self.calls: list[Dict[str, Any]] = []
+
+    async def ainvoke(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self.calls.append({"state": state, "config": config})
+        return {"plan_out": PlanOut(plan=["移動"], resp="了解しました。")}
+
+
+@pytest.mark.anyio
+async def test_plan_uses_context_thread_id_for_langgraph_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_graph = _FakeGraph()
+    monkeypatch.setattr(planner, "_PLAN_GRAPH", fake_graph)
+
+    plan_out = await planner.plan("拠点に戻って", {"thread_id": "thread-abc", "run_id": "run-1"})
+
+    assert plan_out.plan == ["移動"]
+    assert fake_graph.calls[0]["config"] == {"configurable": {"thread_id": "thread-abc"}}
+
+
+@pytest.mark.anyio
+async def test_plan_generates_thread_id_when_context_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_graph = _FakeGraph()
+    monkeypatch.setattr(planner, "_PLAN_GRAPH", fake_graph)
+
+    await planner.plan("丸石を掘る", {})
+
+    config = fake_graph.calls[0]["config"]
+    assert isinstance(config, dict)
+    thread_id = config["configurable"]["thread_id"]
+    assert isinstance(thread_id, str)
+    assert len(thread_id) == 32


### PR DESCRIPTION
### Motivation
- Phase 5 requires LangGraph-based persistence and resume by `thread_id`, so caller-side wiring must provide a stable `thread_id` to compiled graphs. 
- This change prepares the codebase to plug in a checkpointer keyed by `thread_id` without changing planner output contracts.

### Description
- Ensure `planner.plan()` always supplies a `configurable.thread_id` to LangGraph by adding `_resolve_thread_id(context)` that reuses `context["thread_id"]` when present or generates a UUID otherwise, and pass it to `graph.ainvoke(..., config={"configurable": {"thread_id": ...}})` in `python/planner/__init__.py`.
- Add regression tests in `tests/test_planner_thread_config.py` that verify (1) explicit `context.thread_id` is forwarded and (2) a fallback thread id is generated when missing.
- Record progress artifacts for Phase 5 by adding `docs/refactor/phase5.md` and updating `docs/refactor/progress.json` to mark Phase 4 completed and Phase 5 in progress.

### Testing
- Ran `PYTHONPATH=python python -m pytest tests/test_planner_thread_config.py tests/test_planner_responses_payload.py`, which completed with `17 passed` (tests passed; OTLP exporter connection warnings were observed but did not affect tests).
- The new tests validate both explicit `thread_id` propagation and automatic UUID generation for missing `thread_id` values, confirming the LangGraph `config` receives `{"configurable": {"thread_id": ...}}` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e597446a1c832ca33075972b531606)