### PR TITLE
Phase6: Docker/Compose 開発フローを build 時依存解決へ移行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help setup-python run-python run-python-dev run-node run-node-dev test-node build-bridge compose-up compose-up-linux-host
+.PHONY: help setup-python run-python run-python-dev run-node run-node-dev test-node build-bridge compose-up compose-up-watch compose-up-linux-host
 
 help:
 	@printf "Available targets:\n"
@@ -12,6 +12,7 @@ help:
 	@printf "  test-node             Run Node unit tests\n"
 	@printf "  build-bridge          Build the Paper AgentBridge plugin\n"
 	@printf "  compose-up            Start the default Docker Compose stack\n"
+	@printf "  compose-up-watch      Start the default Docker Compose stack with --watch\n"
 	@printf "  compose-up-linux-host Start Compose with Linux host-gateway aliases\n"
 
 setup-python:
@@ -37,6 +38,9 @@ build-bridge:
 
 compose-up:
 	docker compose up --build
+
+compose-up-watch:
+	docker compose up --build --watch
 
 compose-up-linux-host:
 	docker compose -f docker-compose.yml -f docker-compose.host-services.yml up --build

--- a/README.md
+++ b/README.md
@@ -162,16 +162,18 @@ Python と Node を同時にホットリロードで動かしたい場合:
 
 ```bash
 cp env.dev.example .env  # まだ .env が無い場合
-docker compose up --build
+docker compose up --build --watch
 ```
 
-- **Node**: `npm ci` 後に `npm run dev`（`tsx`）で自動再起動
-- **Python**: `watchfiles --filter python --ignore-paths .venv -- "python -m mc_bot_agent_entrypoint"` で自動再起動
+- **Node**: `node-bot/Dockerfile` の build 時に `npm ci` で依存を固定し、起動時は `npm run dev` のみ実行
+- **Python**: `python/Dockerfile` の build 時に `pip install -r requirements.txt -c constraints.txt && pip install -e .` を実行し、起動時は `watchfiles ... "python -m mc_bot_agent_entrypoint"` のみ実行
+- Compose の `develop.watch` で `node-bot/` と `python/` を同期し、依存ファイル（`package-lock.json`, `requirements.txt`, `constraints.txt`, `pyproject.toml`）変更時は自動 rebuild
+- `bridge` / `node-bot` / `python-agent` は healthcheck を持ち、`depends_on.condition: service_healthy` で起動順序を制御
 
-Docker Desktop を使う macOS / Windows では上記のままで構いません。Linux で Compose コンテナからホスト上の Paper / OpenTelemetry Collector へ到達させたい場合は、`host-gateway` を追加する override を重ねて起動してください。
+`make compose-up-watch` でも同じ起動が可能です。Docker Desktop を使う macOS / Windows では上記のままで構いません。Linux で Compose コンテナからホスト上の Paper / OpenTelemetry Collector へ到達させたい場合は、`host-gateway` を追加する override を重ねて起動してください。
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.host-services.yml up --build
+docker compose -f docker-compose.yml -f docker-compose.host-services.yml up --build --watch
 ```
 
 ## 設定（.env）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,17 +24,22 @@ services:
       # - "19071:19071"
       # ホストで Paper を使い続けたい場合は、Compose 側の公開ポートをずらす（例: "19072:19071"）か、bridge サービスを起動しない運用に切り替えてください。
       - "19072:19071"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -lc '</dev/tcp/127.0.0.1/19071'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 40s
     restart: unless-stopped
 
   node-bot:
     # TypeScript ソースをウォッチしながら Mineflayer ボットを再起動する開発用サービス
-    image: node:22
-    # ↑ Mineflayer v4.33.0 以降が要求する Node.js 22 系をベースイメージで確保し、
-    #    古い Node.js で互換バージョン（4.25.0 など）がインストールされることによる
-    #    プロトコル解析失敗（PartialReadError）を防止する。
-    working_dir: /app
+    build:
+      context: .
+      dockerfile: node-bot/Dockerfile
+    working_dir: /app/node-bot
     volumes:
-      - ./:/app
+      - ./node-bot:/app/node-bot
     env_file:
       - .env
     environment:
@@ -50,26 +55,45 @@ services:
       OTEL_TRACES_SAMPLER_RATIO: ${OTEL_TRACES_SAMPLER_RATIO:-1.0}
       AGENT_BRIDGE_LOG_LEVEL: ${AGENT_BRIDGE_LOG_LEVEL:-warn}
       AGENT_LOG_LEVEL: ${AGENT_LOG_LEVEL:-warn}
-    command:
-      - bash
-      - -lc
-      - |
-        cd node-bot \
-        && npm ci \
-        && npm run dev
+    command: ["npm", "run", "dev"]
     ports:
       - "8765:8765"
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "const net=require('node:net');const s=net.connect({host:'127.0.0.1',port:8765},()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1));"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     stdin_open: true
     tty: true
     depends_on:
-      - bridge
+      bridge:
+        condition: service_healthy
+    develop:
+      watch:
+        - action: sync
+          path: ./node-bot
+          target: /app/node-bot
+          ignore:
+            - node_modules/
+            - dist/
+        - action: rebuild
+          path: ./node-bot/package-lock.json
 
   python-agent:
     # Python エージェントを watchfiles で自動再実行する開発用サービス
-    image: python:3.12
+    build:
+      context: .
+      dockerfile: python/Dockerfile
     working_dir: /app
     volumes:
-      - ./:/app
+      - ./python:/app/python
+      - ./tests:/app/tests
+      - ./contracts:/app/contracts
     env_file:
       - .env
     environment:
@@ -79,17 +103,45 @@ services:
       AGENT_WS_PORT: ${AGENT_WS_PORT:-9000}
       BRIDGE_URL: ${COMPOSE_BRIDGE_URL:-http://bridge:19071}
       WATCHFILES_FORCE_POLLING: "true"
-      PYTHONPATH: ${PYTHONPATH:-/app:/app/python}
     command:
-      - bash
-      - -lc
-      - |
-        # watchfiles CLI ではコマンド全体を 1 引数として渡さないと Python が対話モードで起動してしまい、
-        # エージェントがポートをリッスンしないため明示的にクォートする。プロジェクトルートのまま
-        # python 配下を監視し、モジュール検索パスを /app に残して ModuleNotFound エラーを防ぐ。
-        pip install --no-cache-dir -r requirements.txt -c constraints.txt && \
-        watchfiles --filter python --ignore-paths .venv -- "python -m python"
+      - watchfiles
+      - --filter
+      - python
+      - --ignore-paths
+      - .venv
+      - --
+      - python -m mc_bot_agent_entrypoint
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import socket; s=socket.create_connection(('127.0.0.1', 9000), 2); s.close()"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     stdin_open: true
     tty: true
     depends_on:
-      - bridge
+      bridge:
+        condition: service_healthy
+      node-bot:
+        condition: service_healthy
+    develop:
+      watch:
+        - action: sync
+          path: ./python
+          target: /app/python
+        - action: sync
+          path: ./tests
+          target: /app/tests
+        - action: sync
+          path: ./contracts
+          target: /app/contracts
+        - action: rebuild
+          path: ./requirements.txt
+        - action: rebuild
+          path: ./constraints.txt
+        - action: rebuild
+          path: ./pyproject.toml

--- a/docs/refactor/phase6.md
+++ b/docs/refactor/phase6.md
@@ -1,0 +1,28 @@
+## Phase 6 完了報告
+- 変更概要:
+  - Compose の Node/Python サービスを Dockerfile build 前提へ切り替え、起動時 install（`npm ci` / `pip install`）を除去。
+  - `develop.watch` を導入し、ソース同期と依存ファイル変更時 rebuild を分離して watcher の責務を整理。
+  - `bridge` / `node-bot` / `python-agent` に healthcheck を追加し、`depends_on.condition: service_healthy` で起動順序を明示。
+  - `make compose-up-watch` を追加し、README の Compose 手順を `docker compose up --build --watch` 基準へ更新。
+- 主な変更ファイル:
+  - `docker-compose.yml`
+  - `python/Dockerfile`
+  - `node-bot/Dockerfile`
+  - `Makefile`
+  - `README.md`
+  - `docs/refactor/progress.json`
+- 互換性影響:
+  - Compose 利用時は build で依存解決済みイメージを使うため、初回起動時間は増えるが再起動時の安定性と再現性は向上。
+  - `docker compose up` でも動作するが、開発中のホットリロードは `--watch`（または `make compose-up-watch`）利用を推奨。
+  - Bridge は引き続き `bridge-plugin/build/libs` の jar を mount する運用を維持（Phase 7 以降で監視/運用手順を追加検討）。
+- 実行したコマンド:
+  - `PYTHONPATH=python python -m pytest tests/test_planner_thread_config.py`
+  - `bash scripts/run-node-bot.sh test`
+  - `docker compose config`
+- テスト結果:
+  - Python テストは成功。
+  - Node テストは実行環境が Node 20 のため失敗（要件は Node 22）。
+  - `docker compose config` は実行環境に docker コマンドが無いため未実行。
+- 残課題:
+  - Node 22 / Docker が利用可能な環境で `docker compose up --build --watch` の起動スモークを取り、healthcheck と watch の実挙動を確認する。
+  - Phase 7 で可観測性強化（trace/run/message ID の end-to-end）と architecture 文書更新を実施する。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,6 +1,6 @@
 {
   "updated_at": "2026-04-20",
-  "current_phase": 5,
+  "current_phase": 6,
   "phases": [
     {
       "phase": 0,
@@ -55,7 +55,7 @@
     {
       "phase": 5,
       "name": "LangGraph persistence / interrupt 化",
-      "status": "in_progress",
+      "status": "completed",
       "artifacts": [
         "python/planner/__init__.py",
         "tests/test_planner_thread_config.py",
@@ -65,7 +65,14 @@
     {
       "phase": 6,
       "name": "Docker / Compose 開発フロー更新",
-      "status": "pending"
+      "status": "completed",
+      "artifacts": [
+        "docker-compose.yml",
+        "python/Dockerfile",
+        "node-bot/Dockerfile",
+        "docs/refactor/phase6.md",
+        "README.md"
+      ]
     },
     {
       "phase": 7,

--- a/node-bot/Dockerfile
+++ b/node-bot/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app/node-bot
+
+COPY node-bot/package*.json ./
+RUN npm ci
+
+COPY node-bot/ ./
+
+EXPOSE 8765
+
+CMD ["npm", "run", "dev"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt constraints.txt pyproject.toml README.md ./
+COPY python ./python
+
+RUN pip install --no-cache-dir -r requirements.txt -c constraints.txt \
+    && pip install --no-cache-dir -e .
+
+EXPOSE 9000
+
+CMD ["watchfiles", "--filter", "python", "--ignore-paths", ".venv", "--", "python -m mc_bot_agent_entrypoint"]


### PR DESCRIPTION
### Motivation
- 開発用 Compose が起動時に `npm ci` / `pip install` を実行するため再現性と起動安定性が低く、Phase6 で build 時依存解決へ移行する必要があった。 
- ホットリロード時のファイル同期と依存再構築を分離して watch の責務を明確化する必要があった。 
- 起動順序とサービス健全性の保証のために `healthcheck` と `depends_on.condition: service_healthy` を導入する必要があった。

### Description
- `node-bot/Dockerfile` を追加し、`npm ci` を build ステップで実行するようにして起動時の依存解決を除去した。 
- `python/Dockerfile` を追加し、`pip install -r requirements.txt -c constraints.txt` と `pip install -e .` を build ステップで実行するようにした。 
- `docker-compose.yml` を更新して `node-bot` / `python-agent` を `build:` ベースへ切替え、起動コマンドから install を除去し `healthcheck` と `develop.watch` を導入した。 
- `Makefile` に `compose-up-watch` を追加し、`README.md` の Compose 手順を `docker compose up --build --watch` 基準へ更新した。 
- `docs/refactor/phase6.md` を追加し、`docs/refactor/progress.json` を Phase 6 完了に更新した。

### Testing
- `PYTHONPATH=python python -m pytest tests/test_planner_thread_config.py` を実行しテストは `2 passed` で成功した。 
- `bash scripts/run-node-bot.sh test` を実行したが、実行環境の Node.js が v20 のため Node v22 要件で失敗した（環境依存での失敗）。 
- `docker compose config` はこの環境に `docker` が無いため未実行で確認不能だった。 
- `python -c 'import yaml; yaml.safe_load(open("docker-compose.yml"))'` により Compose YAML はパース可能であることを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59aa3d120832c919a8c9523583f48)