### PR TITLE
docs: Phase7の設計文書を追加しリファクタ進捗を更新

### DIFF
--- a/docs/refactor/architecture.md
+++ b/docs/refactor/architecture.md
@@ -1,0 +1,115 @@
+# リファクタ後アーキテクチャ（Phase 7 時点）
+
+## 1. 目的
+本書は `mc-bot-egent-practice-1` の基盤刷新で、**どの契約を正本として運用するか**を明確化する。
+
+- 見た目の多機能化より、契約の正本化・再現性・再開可能性を優先する。
+- 実装詳細より、責務境界と拡張ポイントを先に共有する。
+
+## 2. 全体構成
+
+- `python/`:
+  - planner（Structured Outputs / LangGraph 実行）
+  - runtime（transport envelope validate、WebSocket ingress）
+- `node-bot/`:
+  - Minecraft 操作実行、Python との長寿命 WebSocket 連携
+  - transport envelope 生成/検証
+- `bridge-plugin/`:
+  - Paper plugin + HTTP ブリッジ
+  - Bridge 起点のイベント受け渡し（Phase 7 では envelope 統合の監視対象）
+- `contracts/transport-envelope.schema.json`:
+  - Node / Python / Bridge で共有する transport 契約
+
+## 3. Transport Envelope 契約
+
+### 3.1 正本
+- 正本: `contracts/transport-envelope.schema.json`
+- 必須キー:
+  - `version`
+  - `trace_id`
+  - `run_id`
+  - `message_id`
+  - `timestamp`
+  - `source`
+  - `kind` (`command` / `event` / `status` / `error`)
+  - `name`
+  - `body`
+
+### 3.2 バージョン運用
+- 受信側は envelope validate を必須とする。
+- version 不一致は握りつぶさず、`error/status` で明示する。
+- legacy payload は adapter 1 箇所で受ける（最終的に削除対象）。
+
+## 4. Planner の schema-first 契約
+
+- planner 出力は Pydantic schema を正本にする。
+- プロンプトは「JSON 強制」ではなく、計画品質（分解/制約/優先度）を担保する責務へ寄せる。
+- refusal / 欠損 / 型不整合は「修理前提」ではなく制御された失敗として扱う。
+
+## 5. 実行永続化・interrupt/resume
+
+### 5.1 run/thread の責務
+- `thread_id`: LangGraph の会話/実行スレッド単位（再開キー）。
+- `run_id`: 単一実行フローの識別子（ログ/トレース相関）。
+- `trace_id`: サービス横断で 1 リクエスト連鎖を追跡する相関キー。
+- `message_id`: transport メッセージ単位の識別子。
+
+### 5.2 persistence
+- LangGraph 実行は checkpointer 前提で設計する。
+- local/dev は SQLite 系、test は in-memory を既定にする。
+- production backend は設定で差し替え可能に保つ。
+
+### 5.3 confirmation
+- 確認待ちは `interrupt()` ベースで停止し、resume 入力を受けて継続する。
+- queue は ingress バッファに寄せ、実行状態の唯一正本にしない。
+
+## 6. dev/prod 設定分離
+
+- `env.dev.example`:
+  - 開発効率重視（ローカル開発前提）
+- `env.prod.example`:
+  - 安全側デフォルト（公開範囲抑制、認証前提）
+
+運用時は「どちらを正本として参照するか」を README と Compose で一致させる。
+
+## 7. CI / Docker / Compose の正本
+
+- CI は Python / Node / Bridge の最低 build/test を自動実行。
+- Node install は `npm ci` を正本とし、lockfile を再現性の基準にする。
+- Docker は build 時に依存解決し、起動時 install 前提を避ける。
+- 開発時は `docker compose up --build --watch` を基準フローとする。
+
+## 8. 可観測性の運用方針（Phase 7 残課題を含む）
+
+### 8.1 必須方針
+- 主要ログ/イベント/エラーに `trace_id` / `run_id` / `message_id` を付与する。
+- 受信→planner→tool→送信を横断追跡可能にする。
+- 機密値（token, secret, 生 prompt 全文）は redact する。
+
+### 8.2 今後の実装タスク
+- metrics:
+  - queue/backlog length
+  - planner latency
+  - tool latency
+  - interrupt 回数
+  - resume 成功/失敗
+  - transport error 数
+- error taxonomy:
+  - transport / planner / tool / infra で分類し、ダッシュボード化可能な形式で出力する。
+
+## 9. 拡張ポイント（Phase 8 最小導入）
+
+- `Skill` 永続表現インターフェース
+- `Reflection` 保存先インターフェース
+- plan 実行評価イベント記録
+- 成功手順を再利用する registry 基盤
+
+> 注意: 本刷新では自律学習系をフル実装しない。拡張点のみを低リスクで導入する。
+
+## 10. Owner 判断が必要な項目
+
+- LICENSE の最終選定
+- 本番 secret 実値
+- prod dashboard 公開可否
+- 本番認証要件（Microsoft auth 等）
+- 本番 checkpointer backend（例: Postgres）

--- a/docs/refactor/phase7.md
+++ b/docs/refactor/phase7.md
@@ -1,0 +1,25 @@
+## Phase 7 進捗報告（Slice 1: architecture 文書化と残課題固定）
+- 変更概要:
+  - `docs/refactor/architecture.md` を追加し、刷新後の責務境界（transport envelope / planner schema-first / interrupt-resume / ID 体系 / env 分離 / CI-Docker 正本）を明文化。
+  - 可観測性強化の残課題（metrics, error taxonomy, redact）を次スライスで実装可能な粒度に切り出し。
+  - `docs/refactor/progress.json` を Phase 7 `in_progress` に更新し、現行フェーズを durable に記録。
+  - `plans/refactor-foundation-phase7-8.md` を追加し、受け入れ条件・検証コマンド・次アクションを固定。
+- 主な変更ファイル:
+  - `docs/refactor/architecture.md`
+  - `docs/refactor/phase7.md`
+  - `docs/refactor/progress.json`
+  - `plans/refactor-foundation-phase7-8.md`
+- 互換性影響:
+  - 実行コードへの直接影響はなし（ドキュメント/進捗管理のみ）。
+  - 次スライスで observability 実装を行う前提を明文化。
+- 実行したコマンド:
+  - `python -m json.tool docs/refactor/progress.json >/dev/null`
+  - `rg -n "Phase 7|trace_id|run_id|message_id|interrupt|thread_id|env.dev.example|env.prod.example" docs/refactor/architecture.md`
+  - `git diff -- docs/refactor/progress.json docs/refactor/architecture.md docs/refactor/phase7.md plans/refactor-foundation-phase7-8.md`
+- テスト結果:
+  - JSON 形式検証と内容 grep は成功。
+  - 本 slice はコード変更なしのため build/test は未実施（次 slice で observability 実装時に実施）。
+- 残課題:
+  - Node/Python/Bridge のログ文脈へ `trace_id` / `run_id` / `message_id` の網羅伝搬。
+  - metrics と error taxonomy の実装。
+  - legacy adapter 以外の重複コード整理。

--- a/docs/refactor/progress.json
+++ b/docs/refactor/progress.json
@@ -1,6 +1,6 @@
 {
   "updated_at": "2026-04-20",
-  "current_phase": 6,
+  "current_phase": 7,
   "phases": [
     {
       "phase": 0,
@@ -77,7 +77,11 @@
     {
       "phase": 7,
       "name": "可観測性・重複整理・最終ドキュメント化",
-      "status": "pending"
+      "status": "in_progress",
+      "artifacts": [
+        "docs/refactor/architecture.md",
+        "plans/refactor-foundation-phase7-8.md"
+      ]
     },
     {
       "phase": 8,

--- a/plans/refactor-foundation-phase7-8.md
+++ b/plans/refactor-foundation-phase7-8.md
@@ -1,0 +1,56 @@
+# Task Plan: refactor-foundation-phase7-8
+
+## Metadata
+- Owner: Codex
+- Branch: current working branch
+- Related issue / ticket: Codex作業指示書「mc-bot-egent-practice-1 基盤刷新」Phase 7-8
+- Last updated (UTC): 2026-04-20
+
+## 1. 目的 (Goal)
+- Phase 7/8 の完了に向け、可観測性・重複整理・最終ドキュメント化と研究拡張ポイントの最低限導入を、安全側で段階的に進める。
+
+## 2. 非目標 (Non-goals)
+- 既存 transport/planner の全面作り直し。
+- 本番 secret、LICENSE、本番 checkpointer backend の決定。
+
+## 3. 対象範囲 (Scope)
+- 変更対象ディレクトリ / モジュール:
+  - `docs/refactor/`
+  - `plans/`
+- 影響を受ける契約 (API, schema, env など):
+  - 既存 `contracts/transport-envelope.schema.json` の運用ルール（仕様追加なし）。
+
+## 4. マイルストーン
+| ID | マイルストーン | 状態 (Done/Blocked/Cancelled) | メモ |
+| --- | --- | --- | --- |
+| M1 | Phase 7 の現状整理と architecture 文書の新規作成 | Done | `docs/refactor/architecture.md` を追加 |
+| M2 | progress/計画の durable 更新 | Done | `docs/refactor/progress.json` と本計画を更新 |
+| M3 | Phase 7 実装（可観測性/重複整理）残件の切り出し | Done | architecture と phase7 で残課題を明示 |
+
+## 5. 受け入れ条件 (Acceptance Criteria)
+- [x] `docs/refactor/architecture.md` が存在し、新設計（envelope, planner schema-first, interrupt/resume, ID 意味, dev/prod env 差分）を説明している。
+- [x] `docs/refactor/progress.json` に現在フェーズの状態が反映されている。
+- [x] 次セッションで迷わないよう、未完了の可観測性/研究要素を残課題として構造化している。
+
+## 6. 検証コマンド (Verification)
+- [x] `python -m json.tool docs/refactor/progress.json >/dev/null`
+- [x] `rg -n "Phase 7|trace_id|run_id|message_id|interrupt|thread_id|env.dev.example|env.prod.example" docs/refactor/architecture.md`
+- [x] `git diff -- docs/refactor/progress.json docs/refactor/architecture.md plans/refactor-foundation-phase7-8.md`
+
+## 7. 既知 Blocker
+- なし（本スライスはドキュメントと進捗正規化に限定）。
+
+## 8. Feature Flag / Rollback（必要時のみ）
+- Flag: なし
+- Rollback 手順: 追加ドキュメント削除 + progress 差し戻し
+
+## 9. ステータスログ
+- 2026-04-20: Phase 6 完了時点の `progress.json` を確認し、Phase 7 の docs 着手。
+- 2026-04-20: `docs/refactor/architecture.md` を作成し、現行アーキテクチャと残課題を記録。
+- 2026-04-20: `progress.json` を Phase 7 `in_progress` に更新し、次アクションを固定。
+
+## 10. 停止時の最終状態
+- 最終状態: Done
+- 停止理由（Blocked/Cancelled の場合は必須）: 
+- 再開条件: Phase 7 のコード実装（ID 伝搬強化・metrics 整備・重複除去）に着手する。
+- 次の最短アクション: `docs/refactor/phase7.md` を追加し、実装差分と検証結果を積み上げる。


### PR DESCRIPTION
### Motivation
- Phase 7（可観測性・重複整理・最終ドキュメント化）着手のため、刷新後の正本アーキテクチャと次スライスの残課題を明文化する必要があった。 
- ドキュメントと進捗を durable に残して次フェーズ（実装）へスムースに移行できる状態にするため。 

### Description
- `docs/refactor/architecture.md` を新規追加し、transport envelope / planner schema-first / interrupt/resume / ID 体系 / dev/prod 設定分離 / CI・Docker 方針等の設計を整理した。 
- `docs/refactor/phase7.md` を新規追加して Slice 1 の変更概要・検証手順・残課題を定型フォーマットで記録した。 
- `plans/refactor-foundation-phase7-8.md` を新規追加し、Phase7-8 の目的・受け入れ条件・検証コマンド・次アクションを明文化した。 
- `docs/refactor/progress.json` を更新し `current_phase` を `7` に進め、Phase 7 を `in_progress` にして成果物を登録した（変更はドキュメント/進捗管理のみで実行コードは変更していない）。 

### Testing
- `python -m json.tool docs/refactor/progress.json >/dev/null` により JSON 構文検証を実行し成功した。 
- `rg -n "Phase 7|trace_id|run_id|message_id|interrupt|thread_id|env.dev.example|env.prod.example" docs/refactor/architecture.md` により主要キーワードの存在を確認し成功した。 
- 変更差分確認を `git diff -- docs/refactor/progress.json docs/refactor/architecture.md docs/refactor/phase7.md plans/refactor-foundation-phase7-8.md` で行い期待通りのファイル追加/更新があることを検証した。 
- 本 PR はドキュメントのみの変更のためコードビルド/ユニットテストは未実行で、実装フェーズでの観測性・伝搬テストは次スライスで実施予定である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59ea06b38832c80e5f36747f837e0)