### PR TITLE
docs: 最終受け入れ再検証の計画と結果を追加

### DIFF
--- a/docs/refactor/final-validation.md
+++ b/docs/refactor/final-validation.md
@@ -1,0 +1,42 @@
+# Final Validation Snapshot (2026-04-20)
+
+基盤刷新（Phase 0〜8）後の受け入れ観点を、現行実行環境で再検証した記録。
+
+## 実行結果サマリ
+
+| 区分 | コマンド | 結果 | 補足 |
+| --- | --- | --- | --- |
+| Python 環境構築 | `bash scripts/setup-python-env.sh` | ✅ 成功 | `.venv` に依存導入 + editable install 完了 |
+| Python テスト | `source .venv/bin/activate && python -m pytest tests` | ✅ 成功 | `105 passed` |
+| Node テスト | `bash scripts/run-node-bot.sh test` | ⚠️ 環境制約 | Node `v20.19.6`。スクリプト要件は 22+ |
+| Node build | `bash scripts/run-node-bot.sh build` | ⚠️ 環境制約 | 同上 |
+| Bridge build | `bash scripts/build-bridge-plugin.sh` | ✅ 成功 | Gradle `shadowJar` 成功 |
+| Compose config | `docker compose config` | ⚠️ 環境制約 | `docker: command not found` |
+
+## 受け入れ観点に対する判定
+
+1. CI green: この環境からは CI 実行不可。既存 workflow は `.github/workflows/ci.yml` に定義済みで、ローカル検証では代替として各入口を実行。
+2. Python / Node / Bridge build/test:
+   - Python と Bridge は成功。
+   - Node は環境 Node バージョンにより未実施（要 Node 22+）。
+3. planner schema-first, interrupt/resume, envelope, Docker/README/doc:
+   - 既存の Phase ドキュメントと成果物により実装済みとして追跡可能（`docs/refactor/phase3.md`〜`phase8.md` 参照）。
+
+## Phase 8 完了報告
+- 変更概要: 基盤刷新の受け入れ再検証として、実行コマンドの最新結果を固定化。
+- 主な変更ファイル:
+  - `docs/refactor/final-validation.md`
+  - `plans/refactor-foundation-final-validation.md`
+- 互換性影響: なし（ドキュメント追加のみ）。
+- 実行したコマンド:
+  - `bash scripts/setup-python-env.sh`
+  - `source .venv/bin/activate && python -m pytest tests`
+  - `bash scripts/run-node-bot.sh test`
+  - `bash scripts/run-node-bot.sh build`
+  - `bash scripts/build-bridge-plugin.sh`
+  - `docker compose config`
+- テスト結果:
+  - Python / Bridge は成功。
+  - Node / Docker は環境制約で未達。
+- 残課題:
+  - Node 22+ と Docker が有効な環境での追試結果を追加し、受け入れテスト 1,2,6 を最終確定する。

--- a/plans/refactor-foundation-final-validation.md
+++ b/plans/refactor-foundation-final-validation.md
@@ -1,0 +1,59 @@
+# Task Plan: refactor-foundation-final-validation
+
+## Metadata
+- Owner: Codex
+- Branch: current working branch
+- Related issue / ticket: Codex作業指示書「mc-bot-egent-practice-1 基盤刷新」最終受け入れ再検証
+- Last updated (UTC): 2026-04-20
+
+## 1. 目的 (Goal)
+- Phase 0〜8 の成果物が現行リポジトリで再現可能かを再検証し、受け入れ判断に必要な証跡を固定する。
+
+## 2. 非目標 (Non-goals)
+- 新規機能の追加。
+- Node 実行環境（22+）や Docker 未導入環境の外部制約をコード変更で迂回すること。
+
+## 3. 対象範囲 (Scope)
+- 変更対象ディレクトリ / モジュール:
+  - `plans/`
+  - `docs/refactor/`
+- 影響を受ける契約 (API, schema, env など):
+  - なし（検証結果の記録のみ）。
+
+## 4. マイルストーン
+| ID | マイルストーン | 状態 (Done/Blocked/Cancelled) | メモ |
+| --- | --- | --- | --- |
+| M1 | 検証コマンド実行（Python/Node/Bridge/Compose） | Done | Node 22 / Docker 不在は環境 Blocker として記録 |
+| M2 | 最終検証ドキュメント化 | Done | `docs/refactor/final-validation.md` を追加 |
+| M3 | 計画ファイルの状態整合 | Done | ステータスログと停止状態を確定 |
+
+## 5. 受け入れ条件 (Acceptance Criteria)
+- [x] 受け入れテスト観点（Python / Node / Bridge / compose config）を実行し、成否と理由を記録している。
+- [x] 環境起因の失敗と実装修正が必要な失敗を区別して記録している。
+- [x] 次アクション（Node 22 / Docker 利用環境での追試）が明示されている。
+
+## 6. 検証コマンド (Verification)
+- [x] `bash scripts/setup-python-env.sh`
+- [x] `source .venv/bin/activate && python -m pytest tests`
+- [x] `bash scripts/run-node-bot.sh test`
+- [x] `bash scripts/run-node-bot.sh build`
+- [x] `bash scripts/build-bridge-plugin.sh`
+- [x] `docker compose config`
+
+## 7. 既知 Blocker
+- Node 実行バージョンが `v20.19.6` のため Node 系検証が停止（22+ 必須）。
+- Docker CLI が未導入で `docker compose config` を実行不可。
+
+## 8. Feature Flag / Rollback（必要時のみ）
+- Flag: なし
+- Rollback 手順: 追加した計画/検証ドキュメントを削除すれば差し戻し可能。
+
+## 9. ステータスログ
+- 2026-04-20: 検証コマンドを実行し、Python/Bridge は成功、Node/Docker は環境 Blocker を確認。
+- 2026-04-20: `docs/refactor/final-validation.md` を追加し、受け入れ観点の実行結果を固定。
+
+## 10. 停止時の最終状態
+- 最終状態: Done
+- 停止理由（Blocked/Cancelled の場合は必須）:
+- 再開条件: Node 22+ と Docker 利用可能環境で再検証する場合に再開。
+- 次の最短アクション: Node 22 を有効化し `bash scripts/run-node-bot.sh test && bash scripts/run-node-bot.sh build` を再実行。


### PR DESCRIPTION
### Motivation
- Phase 0〜8 の成果物が現行環境で再現可能かを確定し、環境起因の失敗と実装修正が必要な失敗を明確に残すための検証証跡を固定化する。

### Description
- `plans/refactor-foundation-final-validation.md` を追加し、最終受け入れ再検証の目的・検証コマンド・受け入れ条件・既知 Blocker を構造化して記録した。 
- `docs/refactor/final-validation.md` を追加し、実際に実行したコマンドとその結果（成功・失敗・環境制約）をスナップショットとして記録し、コード変更は含めていないことを明示した。

### Testing
- `bash scripts/setup-python-env.sh` は成功し、仮想環境作成と依存導入および editable install が完了した。 
- `source .venv/bin/activate && python -m pytest tests` は成功し、`105 passed` を確認した（OTLP exporter の接続失敗ログはテストには影響しないことを記録）。
- `bash scripts/build-bridge-plugin.sh` は成功し、Gradle の `shadowJar` ビルドが完了した。 
- `bash scripts/run-node-bot.sh test` および `bash scripts/run-node-bot.sh build` は実行環境の Node.js が `v20.19.6` のため停止し失敗（Node 22+ が必要）として記録した。 
- `docker compose config` はローカルに `docker` コマンドが存在しないため実行不可として記録した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a2870628832c8bd41ed083d7f7ad)